### PR TITLE
Add foundational hex grid system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.export/
+.import/
+.godot/

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,23 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+config/name="Bee Hive"
+run/main_scene="res://scenes/Main.tscn"
+
+[input]
+ui_accept={"deadzone":0.5,"events":[{"type":"key","keycode":32,"physical_keycode":32}]}
+ui_left={"deadzone":0.5,"events":[{"type":"key","keycode":4194319,"physical_keycode":80}]}
+ui_right={"deadzone":0.5,"events":[{"type":"key","keycode":4194321,"physical_keycode":79}]}
+ui_up={"deadzone":0.5,"events":[{"type":"key","keycode":4194320,"physical_keycode":82}]}
+ui_down={"deadzone":0.5,"events":[{"type":"key","keycode":4194322,"physical_keycode":81}]}
+
+[rendering]
+renderer/rendering_method="mobile"

--- a/resources/GridConfig.gd
+++ b/resources/GridConfig.gd
@@ -1,0 +1,13 @@
+extends Resource
+class_name GridConfig
+
+## Resource-driven configuration for the hex grid. Adjusting values in the
+## associated .tres file changes how the grid is generated without modifying
+## code.
+@export var radius: int = 3
+@export var cell_size: float = 48.0
+@export var cell_color: Color = Color("#f5e9c6")
+@export var queen_color: Color = Color("#f2c14e")
+@export var cursor_color: Color = Color("#f7f7ff")
+@export var selection_color: Color = Color("#f08a4b")
+@export var background_color: Color = Color("#2a2a2a")

--- a/resources/GridConfig.tres
+++ b/resources/GridConfig.tres
@@ -1,0 +1,10 @@
+[gd_resource type="GridConfig" load_steps=2 format=3 uid="uid://gridconfig"]
+
+[resource]
+radius = 3
+cell_size = 52.0
+cell_color = Color(0.956863, 0.913725, 0.776471, 1)
+queen_color = Color(0.94902, 0.756863, 0.305882, 1)
+cursor_color = Color(0.976471, 0.976471, 1, 0.6)
+selection_color = Color(0.941176, 0.541176, 0.294118, 1)
+background_color = Color(0.141176, 0.141176, 0.141176, 1)

--- a/scenes/HexCell.tscn
+++ b/scenes/HexCell.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=3 uid="uid://hexcell"]
+
+[ext_resource type="Script" path="res://scripts/grid/HexCell.gd" id="1_9ocxy"]
+
+[node name="HexCell" type="Node2D"]
+script = ExtResource("1_9ocxy")
+
+[node name="Polygon2D" type="Polygon2D" parent="."]
+color = Color(0.952941, 0.905882, 0.780392, 1)
+texture = null

--- a/scenes/HexCursor.tscn
+++ b/scenes/HexCursor.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3 uid="uid://hexcursor"]
+
+[ext_resource type="Script" path="res://scripts/grid/HexCursor.gd" id="1_mwe5c"]
+
+[node name="HexCursor" type="Node2D"]
+script = ExtResource("1_mwe5c")
+
+[node name="Line2D" type="Line2D" parent="."]
+default_color = Color(0.976471, 0.976471, 1, 0.6)
+width = 3.0
+joint_mode = 2
+antialiased = true

--- a/scenes/HexGrid.tscn
+++ b/scenes/HexGrid.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=3 uid="uid://hexgrid"]
+
+[ext_resource type="Script" path="res://scripts/grid/HexGrid.gd" id="1_m45n4"]
+[ext_resource type="Resource" path="res://resources/GridConfig.tres" id="2_dcgwp"]
+
+[node name="HexGrid" type="Node2D"]
+script = ExtResource("1_m45n4")
+grid_config = ExtResource("2_dcgwp")

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,0 +1,25 @@
+[gd_scene load_steps=4 format=3 uid="uid://main"]
+
+[ext_resource type="PackedScene" path="res://scenes/HexGrid.tscn" id="1_kg8yr"]
+[ext_resource type="Script" path="res://scripts/input/InputController.gd" id="2_buqfh"]
+[ext_resource type="Script" path="res://scripts/Main.gd" id="3_p3b4o"]
+
+[node name="Main" type="Node2D"]
+script = ExtResource("3_p3b4o")
+
+[node name="Background" type="ColorRect" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -640.0
+offset_top = -360.0
+offset_right = 640.0
+offset_bottom = 360.0
+color = Color(0.141176, 0.141176, 0.141176, 1)
+z_index = -10
+
+[node name="HexGrid" parent="." instance=ExtResource("1_kg8yr")]
+
+[node name="InputController" type="Node" parent="."]
+script = ExtResource("2_buqfh")
+hex_grid_path = NodePath("../HexGrid")

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -1,0 +1,10 @@
+extends Node2D
+
+const HexGrid := preload("res://scripts/grid/HexGrid.gd")
+
+@onready var background: ColorRect = $Background
+@onready var hex_grid: HexGrid = $HexGrid
+
+func _ready() -> void:
+    if hex_grid and hex_grid.grid_config:
+        background.color = hex_grid.grid_config.background_color

--- a/scripts/core/Coord.gd
+++ b/scripts/core/Coord.gd
@@ -1,0 +1,62 @@
+extends RefCounted
+
+## Helper class for handling axial coordinate math and conversions between
+## axial coordinates and world positions for a flat-topped hex grid layout.
+class_name Coord
+
+const SQRT3 := sqrt(3.0)
+
+## Direction vectors for the six neighboring axial coordinates. The order is
+## clockwise starting at the eastern neighbor.
+const DIRECTIONS := [
+    Vector2i(1, 0),
+    Vector2i(1, -1),
+    Vector2i(0, -1),
+    Vector2i(-1, 0),
+    Vector2i(-1, 1),
+    Vector2i(0, 1),
+]
+
+static func axial_to_world(axial: Vector2i, cell_size: float) -> Vector2:
+    ## Converts an axial coordinate to a 2D world-space position. Assumes a
+    ## flat-topped hex layout and positions the hex at the returned Vector2.
+    var q := float(axial.x)
+    var r := float(axial.y)
+    var x := cell_size * (1.5 * q)
+    var y := cell_size * (SQRT3 * (r + q / 2.0))
+    return Vector2(x, y)
+
+static func world_to_axial(position: Vector2, cell_size: float) -> Vector2i:
+    ## Converts a world position to the nearest axial coordinate using cube
+    ## rounding. Suitable for hit detection or positioning the cursor.
+    var q := (2.0 / 3.0 * position.x) / cell_size
+    var r := ((-1.0 / 3.0) * position.x + (SQRT3 / 3.0) * position.y) / cell_size
+    return cube_round(Vector3(q, -q - r, r))
+
+static func cube_round(cube: Vector3) -> Vector2i:
+    var rx := round(cube.x)
+    var ry := round(cube.y)
+    var rz := round(cube.z)
+
+    var x_diff := abs(rx - cube.x)
+    var y_diff := abs(ry - cube.y)
+    var z_diff := abs(rz - cube.z)
+
+    if x_diff > y_diff and x_diff > z_diff:
+        rx = -ry - rz
+    elif y_diff > z_diff:
+        ry = -rx - rz
+    else:
+        rz = -rx - ry
+
+    return Vector2i(int(rx), int(rz))
+
+static func neighbor(axial: Vector2i, direction_index: int) -> Vector2i:
+    direction_index = posmod(direction_index, DIRECTIONS.size())
+    return axial + DIRECTIONS[direction_index]
+
+static func axial_distance(a: Vector2i, b: Vector2i) -> int:
+    var dq := a.x - b.x
+    var dr := a.y - b.y
+    var ds := -a.x - a.y - (-b.x - b.y)
+    return int((abs(dq) + abs(dr) + abs(ds)) / 2)

--- a/scripts/grid/HexCell.gd
+++ b/scripts/grid/HexCell.gd
@@ -1,0 +1,50 @@
+extends Node2D
+
+## Visual representation of a single hex cell. Handles rendering of the hexagon
+## and state transitions for highlighting and selection.
+class_name HexCell
+
+@onready var polygon: Polygon2D = $Polygon2D
+
+var axial: Vector2i = Vector2i.ZERO
+var _cell_size: float = 52.0
+var _base_color: Color = Color.WHITE
+var _selection_color: Color = Color.DARK_GOLDENROD
+var _queen_color: Color = Color.GOLD
+var _is_selected := false
+var _is_queen := false
+
+func configure(axial_coord: Vector2i, cell_size: float, base_color: Color, selection_color: Color, queen_color: Color, is_queen: bool) -> void:
+    axial = axial_coord
+    _cell_size = cell_size
+    _base_color = base_color
+    _selection_color = selection_color
+    _queen_color = queen_color
+    _is_queen = is_queen
+    polygon.polygon = _build_polygon_points(cell_size)
+    _apply_color()
+
+func set_selected(selected: bool) -> void:
+    _is_selected = selected
+    _apply_color()
+
+func toggle_selected() -> void:
+    set_selected(not _is_selected)
+
+func is_selected() -> bool:
+    return _is_selected
+
+func _apply_color() -> void:
+    if _is_selected:
+        polygon.color = _selection_color
+    elif _is_queen:
+        polygon.color = _queen_color
+    else:
+        polygon.color = _base_color
+
+func _build_polygon_points(cell_size: float) -> PackedVector2Array:
+    var points := PackedVector2Array()
+    for i in range(6):
+        var angle := PI / 180.0 * (60.0 * i + 30.0)
+        points.append(Vector2(cos(angle), sin(angle)) * cell_size)
+    return points

--- a/scripts/grid/HexCursor.gd
+++ b/scripts/grid/HexCursor.gd
@@ -1,0 +1,25 @@
+extends Node2D
+
+## Simple cursor that outlines the currently hovered hex cell.
+class_name HexCursor
+
+@onready var outline: Line2D = $Line2D
+var _cell_size: float = 52.0
+
+func configure(cell_size: float, outline_color: Color) -> void:
+    _cell_size = cell_size
+    outline.width = 3.0
+    outline.default_color = outline_color
+    outline.closed = true
+    outline.points = _build_outline_points(_cell_size)
+
+func set_cell_size(cell_size: float) -> void:
+    _cell_size = cell_size
+    outline.points = _build_outline_points(_cell_size)
+
+func _build_outline_points(cell_size: float) -> PackedVector2Array:
+    var points := PackedVector2Array()
+    for i in range(7):
+        var angle := PI / 180.0 * (60.0 * i + 30.0)
+        points.append(Vector2(cos(angle), sin(angle)) * cell_size * 1.02)
+    return points

--- a/scripts/grid/HexGrid.gd
+++ b/scripts/grid/HexGrid.gd
@@ -1,0 +1,88 @@
+extends Node2D
+
+## Primary controller for the hex grid. Responsible for generating cells,
+## managing the cursor, and offering helper conversion functions.
+class_name HexGrid
+
+const Coord := preload("res://scripts/core/Coord.gd")
+const HexCell := preload("res://scripts/grid/HexCell.gd")
+const HexCursor := preload("res://scripts/grid/HexCursor.gd")
+
+@export var grid_config: GridConfig
+@export var cell_scene: PackedScene = preload("res://scenes/HexCell.tscn")
+@export var cursor_scene: PackedScene = preload("res://scenes/HexCursor.tscn")
+
+var cells: Dictionary = {}
+var _cursor_axial: Vector2i = Vector2i.ZERO
+var _cursor_node: HexCursor
+var _selected_cells: Dictionary = {}
+
+func _ready() -> void:
+    if not grid_config:
+        grid_config = load("res://resources/GridConfig.tres")
+    _generate_grid()
+    _spawn_cursor()
+
+func _generate_grid() -> void:
+    for child in get_children():
+        if child is HexCell:
+            remove_child(child)
+            child.queue_free()
+    cells.clear()
+
+    var radius := grid_config.radius
+    for q in range(-radius, radius + 1):
+        for r in range(-radius, radius + 1):
+            if abs(q + r) > radius:
+                continue
+            if abs(q) > radius or abs(r) > radius:
+                continue
+            var axial := Vector2i(q, r)
+            var cell: HexCell = cell_scene.instantiate()
+            add_child(cell)
+            cell.position = Coord.axial_to_world(axial, grid_config.cell_size)
+            var is_queen := axial == Vector2i.ZERO
+            cell.configure(axial, grid_config.cell_size, grid_config.cell_color, grid_config.selection_color, grid_config.queen_color, is_queen)
+            cells[axial] = cell
+
+func _spawn_cursor() -> void:
+    if _cursor_node:
+        remove_child(_cursor_node)
+        _cursor_node.queue_free()
+    _cursor_node = cursor_scene.instantiate()
+    add_child(_cursor_node)
+    _cursor_node.configure(grid_config.cell_size, grid_config.cursor_color)
+    _cursor_node.z_index = 10
+    _cursor_axial = Vector2i.ZERO
+    _update_cursor_position()
+
+func move_cursor(delta: Vector2i) -> void:
+    var target := _cursor_axial + delta
+    if not is_within_grid(target):
+        return
+    _cursor_axial = target
+    _update_cursor_position()
+
+func select_current_hex() -> void:
+    if not cells.has(_cursor_axial):
+        return
+    var cell: HexCell = cells[_cursor_axial]
+    cell.toggle_selected()
+    if cell.is_selected():
+        _selected_cells[_cursor_axial] = cell
+    else:
+        _selected_cells.erase(_cursor_axial)
+
+func is_within_grid(axial: Vector2i) -> bool:
+    return Coord.axial_distance(Vector2i.ZERO, axial) <= grid_config.radius
+
+func axial_to_world(axial: Vector2i) -> Vector2:
+    return Coord.axial_to_world(axial, grid_config.cell_size)
+
+func world_to_axial(position: Vector2) -> Vector2i:
+    return Coord.world_to_axial(position, grid_config.cell_size)
+
+func _update_cursor_position() -> void:
+    if not _cursor_node:
+        return
+    _cursor_node.global_position = axial_to_world(_cursor_axial)

--- a/scripts/input/InputController.gd
+++ b/scripts/input/InputController.gd
@@ -1,0 +1,34 @@
+extends Node
+
+## Handles keyboard input and forwards navigation commands to the hex grid.
+@export var hex_grid_path: NodePath
+
+const HexGrid := preload("res://scripts/grid/HexGrid.gd")
+
+var _hex_grid: HexGrid
+
+const MOVE_VECTORS := {
+    "ui_left": Vector2i(-1, 0),
+    "ui_right": Vector2i(1, 0),
+    "ui_up": Vector2i(0, -1),
+    "ui_down": Vector2i(0, 1),
+}
+
+func _ready() -> void:
+    if hex_grid_path.is_empty():
+        hex_grid_path = NodePath("../HexGrid")
+    _hex_grid = get_node_or_null(hex_grid_path)
+    if not _hex_grid:
+        push_warning("InputController could not find HexGrid node at %s" % hex_grid_path)
+
+func _unhandled_input(event: InputEvent) -> void:
+    if not _hex_grid:
+        return
+    for action in MOVE_VECTORS.keys():
+        if event.is_action_pressed(action):
+            _hex_grid.move_cursor(MOVE_VECTORS[action])
+            get_viewport().set_input_as_handled()
+            return
+    if event.is_action_pressed("ui_accept"):
+        _hex_grid.select_current_hex()
+        get_viewport().set_input_as_handled()

--- a/tests/grid_test.gd
+++ b/tests/grid_test.gd
@@ -1,0 +1,13 @@
+extends RefCounted
+
+const Coord := preload("res://scripts/core/Coord.gd")
+
+func test_axial_conversion_round_trip() -> void:
+    var size := 32.0
+    for q in range(-2, 3):
+        for r in range(-2, 3):
+            if abs(q + r) > 2:
+                continue
+            var position := Coord.axial_to_world(Vector2i(q, r), size)
+            var round_trip := Coord.world_to_axial(position, size)
+            assert(round_trip == Vector2i(q, r))

--- a/themes/default.tres
+++ b/themes/default.tres
@@ -1,0 +1,3 @@
+[gd_resource type="Theme" load_steps=1 format=3 uid="uid://defaulttheme"]
+
+[resource]


### PR DESCRIPTION
## Summary
- set up Godot project skeleton with configurable hex grid resource
- implement axial coordinate helpers, grid generation, and cursor-driven selection logic
- add scenes for main entry, hex cells, and cursor along with input controller and basic test

## Testing
- not run (Godot not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68df358ec77c83229d66095fb0bae71f