### PR TITLE
Clarify cube rounding variable types

### DIFF
--- a/scripts/core/Coord.gd
+++ b/scripts/core/Coord.gd
@@ -34,13 +34,13 @@ static func world_to_axial(position: Vector2, cell_size: float) -> Vector2i:
     return cube_round(Vector3(q, -q - r, r))
 
 static func cube_round(cube: Vector3) -> Vector2i:
-    var rx := round(cube.x)
-    var ry := round(cube.y)
-    var rz := round(cube.z)
+    var rx: float = round(cube.x)
+    var ry: float = round(cube.y)
+    var rz: float = round(cube.z)
 
-    var x_diff := abs(rx - cube.x)
-    var y_diff := abs(ry - cube.y)
-    var z_diff := abs(rz - cube.z)
+    var x_diff: float = abs(rx - cube.x)
+    var y_diff: float = abs(ry - cube.y)
+    var z_diff: float = abs(rz - cube.z)
 
     if x_diff > y_diff and x_diff > z_diff:
         rx = -ry - rz


### PR DESCRIPTION
## Summary
- add explicit float annotations for cube rounding intermediates to avoid Variant inference

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df377f5b708322b013602cef0654fd