### PR TITLE
Fix GridConfig resource loading

### DIFF
--- a/resources/GridConfig.tres
+++ b/resources/GridConfig.tres
@@ -1,6 +1,9 @@
-[gd_resource type="GridConfig" load_steps=2 format=3 uid="uid://gridconfig"]
+[gd_resource type="Resource" load_steps=2 format=3 uid="uid://gridconfig"]
+
+[ext_resource type="Script" path="res://resources/GridConfig.gd" id="1_lm42f"]
 
 [resource]
+script = ExtResource("1_lm42f")
 radius = 3
 cell_size = 52.0
 cell_color = Color(0.956863, 0.913725, 0.776471, 1)


### PR DESCRIPTION
## Summary
- ensure the GridConfig resource file explicitly references its script so it can be instantiated without the editor cache

## Testing
- not run (Godot executable not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68df3d62d2c083229a1e1b5510e030df