### PR TITLE
Center hex grid and use flat-top layout

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -8,3 +8,4 @@ const HexGrid := preload("res://scripts/grid/HexGrid.gd")
 func _ready() -> void:
     if hex_grid and hex_grid.grid_config:
         background.color = hex_grid.grid_config.background_color
+    hex_grid.position = get_viewport_rect().size * 0.5

--- a/scripts/core/Coord.gd
+++ b/scripts/core/Coord.gd
@@ -22,15 +22,15 @@ static func axial_to_world(axial: Vector2i, cell_size: float) -> Vector2:
     ## flat-topped hex layout and positions the hex at the returned Vector2.
     var q := float(axial.x)
     var r := float(axial.y)
-    var x := cell_size * (1.5 * q)
-    var y := cell_size * (SQRT3 * (r + q / 2.0))
+    var x := cell_size * (SQRT3 * (q + r / 2.0))
+    var y := cell_size * (1.5 * r)
     return Vector2(x, y)
 
 static func world_to_axial(position: Vector2, cell_size: float) -> Vector2i:
     ## Converts a world position to the nearest axial coordinate using cube
     ## rounding. Suitable for hit detection or positioning the cursor.
-    var q := (2.0 / 3.0 * position.x) / cell_size
-    var r := ((-1.0 / 3.0) * position.x + (SQRT3 / 3.0) * position.y) / cell_size
+    var q := ((SQRT3 / 3.0) * position.x - (1.0 / 3.0) * position.y) / cell_size
+    var r := ((2.0 / 3.0) * position.y) / cell_size
     return cube_round(Vector3(q, -q - r, r))
 
 static func cube_round(cube: Vector3) -> Vector2i:

--- a/scripts/grid/HexCell.gd
+++ b/scripts/grid/HexCell.gd
@@ -45,6 +45,6 @@ func _apply_color() -> void:
 func _build_polygon_points(cell_size: float) -> PackedVector2Array:
     var points := PackedVector2Array()
     for i in range(6):
-        var angle := PI / 180.0 * (60.0 * i + 30.0)
+        var angle := PI / 180.0 * (60.0 * i)
         points.append(Vector2(cos(angle), sin(angle)) * cell_size)
     return points

--- a/scripts/grid/HexCursor.gd
+++ b/scripts/grid/HexCursor.gd
@@ -20,6 +20,6 @@ func set_cell_size(cell_size: float) -> void:
 func _build_outline_points(cell_size: float) -> PackedVector2Array:
     var points := PackedVector2Array()
     for i in range(7):
-        var angle := PI / 180.0 * (60.0 * i + 30.0)
+        var angle := PI / 180.0 * (60.0 * i)
         points.append(Vector2(cos(angle), sin(angle)) * cell_size * 1.02)
     return points


### PR DESCRIPTION
## Summary
- center the hex grid scene on the viewport so the board sits in the middle of the screen
- update hex geometry math so axial/world conversions produce flat-topped hex positions
- rotate rendered hex cell and cursor polygons to align with the flat-top orientation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df3e6845b48322b4c751fe11346c4e