### PR TITLE
Fix hex grid orientation and cursor alignment

### DIFF
--- a/scripts/core/Coord.gd
+++ b/scripts/core/Coord.gd
@@ -22,15 +22,15 @@ static func axial_to_world(axial: Vector2i, cell_size: float) -> Vector2:
     ## flat-topped hex layout and positions the hex at the returned Vector2.
     var q := float(axial.x)
     var r := float(axial.y)
-    var x := cell_size * (SQRT3 * (q + r / 2.0))
-    var y := cell_size * (1.5 * r)
+    var x := cell_size * (1.5 * q)
+    var y := cell_size * (SQRT3 * (r + q / 2.0))
     return Vector2(x, y)
 
 static func world_to_axial(position: Vector2, cell_size: float) -> Vector2i:
     ## Converts a world position to the nearest axial coordinate using cube
     ## rounding. Suitable for hit detection or positioning the cursor.
-    var q := ((SQRT3 / 3.0) * position.x - (1.0 / 3.0) * position.y) / cell_size
-    var r := ((2.0 / 3.0) * position.y) / cell_size
+    var q := ((2.0 / 3.0) * position.x) / cell_size
+    var r := ((-1.0 / 3.0) * position.x + (SQRT3 / 3.0) * position.y) / cell_size
     return cube_round(Vector3(q, -q - r, r))
 
 static func cube_round(cube: Vector3) -> Vector2i:

--- a/scripts/grid/HexGrid.gd
+++ b/scripts/grid/HexGrid.gd
@@ -94,7 +94,7 @@ func world_to_axial(position: Vector2) -> Vector2i:
 func _update_cursor_position() -> void:
     if not _cursor_node:
         return
-    _cursor_node.global_position = axial_to_world(_cursor_axial)
+    _cursor_node.position = axial_to_world(_cursor_axial)
 
 func _ensure_grid_config() -> bool:
     if grid_config:


### PR DESCRIPTION
## Summary
- adjust axial/world coordinate conversions to match the flat-topped layout
- position the cursor relative to the grid so its highlight stays centered on the selected cell

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df400395c883229ea402ff3e8b5c55