### PR TITLE
Add brood enclosure detection and brood timers

### DIFF
--- a/resources/GridConfig.gd
+++ b/resources/GridConfig.gd
@@ -14,6 +14,7 @@ const CellType := preload("res://scripts/core/CellType.gd")
 @export var selection_color: Color = Color("#f08a4b")
 @export var background_color: Color = Color("#2a2a2a")
 @export var type_colors: Dictionary = {}
+@export var brood_hatch_seconds: float = 10.0
 
 func _init() -> void:
     if type_colors.is_empty():

--- a/resources/GridConfig.tres
+++ b/resources/GridConfig.tres
@@ -11,6 +11,7 @@ queen_color = Color(0.94902, 0.756863, 0.305882, 1)
 cursor_color = Color(0.976471, 0.976471, 1, 0.6)
 selection_color = Color(0.941176, 0.541176, 0.294118, 1)
 background_color = Color(0.141176, 0.141176, 0.141176, 1)
+brood_hatch_seconds = 10.0
 type_colors = {
 0: Color(0.94902, 0.756863, 0.305882, 1),
 1: Color(0.964706, 0.827451, 0.396078, 1),

--- a/resources/QueenEggs.tres
+++ b/resources/QueenEggs.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" load_steps=2 format=3 uid="uid://queeneggs"]
+
+[ext_resource type="Script" path="res://scripts/core/QueenEggs.gd" id="1_1h0t7"]
+
+[resource]
+script = ExtResource("1_1h0t7")
+eggs = 0

--- a/scenes/HexCell.tscn
+++ b/scenes/HexCell.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=2 format=3 uid="uid://hexcell"]
+[gd_scene load_steps=3 format=3 uid="uid://hexcell"]
 
 [ext_resource type="Script" path="res://scripts/grid/HexCell.gd" id="1_9ocxy"]
 
@@ -7,4 +7,10 @@ script = ExtResource("1_9ocxy")
 
 [node name="Polygon2D" type="Polygon2D" parent="."]
 color = Color(0.952941, 0.905882, 0.780392, 1)
+texture = null
+
+[node name="ReadyBadge" type="Polygon2D" parent="."]
+visible = false
+color = Color(1, 0.972549, 0.454902, 1)
+z_index = 1
 texture = null

--- a/scenes/HexGrid.tscn
+++ b/scenes/HexGrid.tscn
@@ -1,8 +1,10 @@
-[gd_scene load_steps=2 format=3 uid="uid://hexgrid"]
+[gd_scene load_steps=3 format=3 uid="uid://hexgrid"]
 
 [ext_resource type="Script" path="res://scripts/grid/HexGrid.gd" id="1_m45n4"]
 [ext_resource type="Resource" path="res://resources/GridConfig.tres" id="2_dcgwp"]
+[ext_resource type="Resource" path="res://resources/QueenEggs.tres" id="3_0jvtc"]
 
 [node name="HexGrid" type="Node2D"]
 script = ExtResource("1_m45n4")
 grid_config = ExtResource("2_dcgwp")
+queen_eggs = ExtResource("3_0jvtc")

--- a/scripts/core/CellData.gd
+++ b/scripts/core/CellData.gd
@@ -5,6 +5,9 @@ class_name CellData
 var cell_type: int = 0
 var complex_id: int = 0
 var color: Color = Color.WHITE
+var brood_has_egg: bool = false
+var brood_hatch_remaining: float = 0.0
+var brood_ready: bool = false
 
 func set_type(new_type: int, new_color: Color) -> void:
     cell_type = new_type

--- a/scripts/core/Coord.gd
+++ b/scripts/core/Coord.gd
@@ -10,11 +10,11 @@ const SQRT3 := sqrt(3.0)
 ## clockwise starting at the eastern neighbor.
 const DIRECTIONS := [
     Vector2i(1, 0),
-    Vector2i(1, -1),
-    Vector2i(0, -1),
-    Vector2i(-1, 0),
-    Vector2i(-1, 1),
     Vector2i(0, 1),
+    Vector2i(-1, 1),
+    Vector2i(-1, 0),
+    Vector2i(0, -1),
+    Vector2i(1, -1),
 ]
 
 static func axial_to_world(axial: Vector2i, cell_size: float) -> Vector2:

--- a/scripts/core/QueenEggs.gd
+++ b/scripts/core/QueenEggs.gd
@@ -1,0 +1,14 @@
+extends Resource
+## Tracks the pool of available eggs that can be assigned to new brood cells.
+class_name QueenEggs
+
+@export var eggs: int = 0
+
+func take(amount: int) -> int:
+    ## Removes up to `amount` eggs from the pool and returns how many were
+    ## actually assigned.
+    if amount <= 0:
+        return 0
+    var taken := min(amount, eggs)
+    eggs -= taken
+    return taken

--- a/scripts/grid/HexCell.gd
+++ b/scripts/grid/HexCell.gd
@@ -5,6 +5,7 @@ extends Node2D
 class_name HexCell
 
 @onready var polygon: Polygon2D = $Polygon2D
+@onready var ready_badge: Polygon2D = $ReadyBadge
 
 var axial: Vector2i = Vector2i.ZERO
 var _cell_size: float = 52.0
@@ -20,6 +21,8 @@ func configure(axial_coord: Vector2i, cell_size: float, selection_color: Color, 
     _cell_color = initial_color
     polygon.polygon = _build_polygon_points(cell_size)
     polygon.modulate = Color.WHITE
+    ready_badge.polygon = _build_polygon_points(cell_size * 0.35)
+    ready_badge.visible = false
     _apply_color()
 
 func set_selected(selected: bool) -> void:
@@ -42,6 +45,9 @@ func flash(duration: float = 0.2) -> void:
     polygon.modulate = Color(1.4, 1.4, 1.4, 1.0)
     _flash_tween = create_tween()
     _flash_tween.tween_property(polygon, "modulate", Color.WHITE, duration)
+
+func set_ready_state(is_ready: bool) -> void:
+    ready_badge.visible = is_ready
 
 func _apply_color() -> void:
     if _is_selected:


### PR DESCRIPTION
## Summary
- detect enclosed empty regions after building and convert them into brood cells while emitting brood lifecycle signals
- manage egg assignment and hatch timers using a configurable QueenEggs resource and grid hatch timing
- refresh cell visuals with brood-ready badges and expose brood state helpers on the grid API

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df4e370eac832287462ebba812c7ab