### PR TITLE
Fix Variant inference warnings in input scripts

### DIFF
--- a/scripts/input/InputController.gd
+++ b/scripts/input/InputController.gd
@@ -10,7 +10,8 @@ const PaletteState := preload("res://scripts/input/PaletteState.gd")
 
 var _hex_grid: HexGrid
 var _palette_state: PaletteState
-var _pending_build_axial = null
+var _pending_build_axial: Vector2i = Vector2i.ZERO
+var _has_pending_build: bool = false
 
 const MOVE_VECTORS := {
     "ui_left": Vector2i(-1, 0),
@@ -40,7 +41,8 @@ func _unhandled_input(event: InputEvent) -> void:
             if _palette_state:
                 if _palette_state.is_open:
                     _palette_state.close()
-                _pending_build_axial = null
+                _has_pending_build = false
+                _pending_build_axial = Vector2i.ZERO
                 if _palette_state.has_in_hand():
                     _palette_state.clear_in_hand()
             get_viewport().set_input_as_handled()
@@ -57,13 +59,14 @@ func _unhandled_input(event: InputEvent) -> void:
             return
         if event.is_action_pressed("ui_accept"):
             var selected_type := _palette_state.confirm_selection()
-            if _pending_build_axial != null and selected_type != CellType.Type.EMPTY:
+            if _has_pending_build and selected_type != CellType.Type.EMPTY:
                 var placed := _hex_grid.try_place_cell(_pending_build_axial, selected_type)
                 if placed:
                     _hex_grid.clear_selection()
             if _palette_state.has_in_hand():
                 _palette_state.clear_in_hand()
-            _pending_build_axial = null
+            _has_pending_build = false
+            _pending_build_axial = Vector2i.ZERO
             get_viewport().set_input_as_handled()
             return
         return
@@ -71,6 +74,7 @@ func _unhandled_input(event: InputEvent) -> void:
     if event.is_action_pressed("ui_accept"):
         if _palette_state:
             _pending_build_axial = _hex_grid.get_cursor_axial()
+            _has_pending_build = true
             _palette_state.open()
         get_viewport().set_input_as_handled()
         return

--- a/scripts/input/PaletteState.gd
+++ b/scripts/input/PaletteState.gd
@@ -12,7 +12,9 @@ signal in_hand_changed(in_hand_type)
 var buildable_types: Array[int] = CellType.buildable_types()
 var is_open: bool = false
 var selected_index: int = 0
-var in_hand_type = null
+const NO_IN_HAND := -1
+
+var in_hand_type: int = NO_IN_HAND
 
 func toggle_open() -> void:
     if is_open:
@@ -24,7 +26,7 @@ func open() -> void:
     if is_open:
         return
     is_open = true
-    if in_hand_type != null:
+    if has_in_hand():
         var idx := buildable_types.find(in_hand_type)
         if idx != -1:
             selected_index = idx
@@ -48,20 +50,22 @@ func confirm_selection() -> int:
         return CellType.Type.EMPTY
     var selected_type := get_selected_type()
     in_hand_type = selected_type
-    emit_signal("in_hand_changed", in_hand_type)
+    emit_signal("in_hand_changed", selected_type)
     close()
     return selected_type
 
 func clear_in_hand() -> void:
-    if in_hand_type == null:
+    if not has_in_hand():
         return
-    in_hand_type = null
-    emit_signal("in_hand_changed", in_hand_type)
+    in_hand_type = NO_IN_HAND
+    emit_signal("in_hand_changed", null)
 
 func has_in_hand() -> bool:
-    return in_hand_type != null
+    return in_hand_type != NO_IN_HAND
 
 func get_in_hand_type():
+    if not has_in_hand():
+        return null
     return in_hand_type
 
 func get_selected_type() -> int:


### PR DESCRIPTION
## Summary
- replace PaletteState's nullable in-hand tracking with a typed sentinel to avoid Variant inference warnings while preserving signal behaviour
- store pending build cursor positions in InputController with explicit Vector2i data and a validity flag instead of using null checks

## Testing
- not run (Godot executable is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df5050780083228ed4b3bc0eca220b