### PR TITLE
Specify type for grid round trip test

### DIFF
--- a/tests/grid_test.gd
+++ b/tests/grid_test.gd
@@ -9,5 +9,5 @@ func test_axial_conversion_round_trip() -> void:
             if abs(q + r) > 2:
                 continue
             var position := Coord.axial_to_world(Vector2i(q, r), size)
-            var round_trip := Coord.world_to_axial(position, size)
+            var round_trip: Vector2i = Coord.world_to_axial(position, size)
             assert(round_trip == Vector2i(q, r))


### PR DESCRIPTION
## Summary
- explicitly type the grid round-trip variable to avoid Variant inference warnings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfaaeda2708322a705cdb8a1799c89