### PR TITLE
Fix QueenEggs taken type annotation

### DIFF
--- a/scripts/core/QueenEggs.gd
+++ b/scripts/core/QueenEggs.gd
@@ -9,6 +9,6 @@ func take(amount: int) -> int:
     ## actually assigned.
     if amount <= 0:
         return 0
-    var taken := min(amount, eggs)
+    var taken: int = min(amount, eggs)
     eggs -= taken
     return taken


### PR DESCRIPTION
## Summary
- annotate the QueenEggs taken variable as an int to avoid Variant inference warnings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfabe64a588322837e6a4f9ea81afc