### PR TITLE
Enforce adjacency rule for cell placement

### DIFF
--- a/resources/GridConfig.gd
+++ b/resources/GridConfig.gd
@@ -15,6 +15,7 @@ const CellType := preload("res://scripts/core/CellType.gd")
 @export var background_color: Color = Color("#2a2a2a")
 @export var type_colors: Dictionary = {}
 @export var brood_hatch_seconds: float = 10.0
+@export var allow_isolated_builds: bool = false
 
 func _init() -> void:
     if type_colors.is_empty():

--- a/resources/GridConfig.tres
+++ b/resources/GridConfig.tres
@@ -11,6 +11,7 @@ queen_color = Color(0.94902, 0.756863, 0.305882, 1)
 cursor_color = Color(0.976471, 0.976471, 1, 0.6)
 selection_color = Color(0.941176, 0.541176, 0.294118, 1)
 background_color = Color(0.141176, 0.141176, 0.141176, 1)
+allow_isolated_builds = false
 brood_hatch_seconds = 10.0
 type_colors = {
 0: Color(0.94902, 0.756863, 0.305882, 1),

--- a/scripts/grid/HexGrid.gd
+++ b/scripts/grid/HexGrid.gd
@@ -132,6 +132,17 @@ func world_to_axial(position: Vector2) -> Vector2i:
         return Vector2i.ZERO
     return Coord.world_to_axial(position, grid_config.cell_size)
 
+func is_build_adjacent_to_existing(q: int, r: int) -> bool:
+    var axial := Vector2i(q, r)
+    for direction: Vector2i in Coord.DIRECTIONS:
+        var neighbor := axial + direction
+        if not _cell_states.has(neighbor):
+            continue
+        var neighbor_data: CellData = _cell_states[neighbor]
+        if neighbor_data.cell_type != CellType.Type.EMPTY:
+            return true
+    return false
+
 func try_place_cell(axial: Vector2i, cell_type: int) -> bool:
     if not _cell_states.has(axial):
         _log_build_failure("Cannot build outside the grid.")
@@ -145,6 +156,9 @@ func try_place_cell(axial: Vector2i, cell_type: int) -> bool:
         return false
     if data.cell_type != CellType.Type.EMPTY:
         _log_build_failure("This cell already holds a specialized structure.")
+        return false
+    if not grid_config.allow_isolated_builds and not is_build_adjacent_to_existing(axial.x, axial.y):
+        _log_build_failure("Placement blocked: must touch an existing cell")
         return false
 
     var color := grid_config.get_color(cell_type)


### PR DESCRIPTION
## Summary
- add a configuration toggle to allow bypassing adjacency enforcement for debugging
- ensure specialized cells may only be placed when adjacent to an existing structure

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfadbfbc5083229b3becba6c1eaf20