### PR TITLE
Expand hex grid radius and refine cursor movement

### DIFF
--- a/resources/GridConfig.gd
+++ b/resources/GridConfig.gd
@@ -6,8 +6,8 @@ const CellType := preload("res://scripts/core/CellType.gd")
 ## Resource-driven configuration for the hex grid. Adjusting values in the
 ## associated .tres file changes how the grid is generated without modifying
 ## code.
-@export var radius: int = 3
-@export var cell_size: float = 48.0
+@export var radius: int = 6
+@export var cell_size: float = 41.6
 @export var cell_color: Color = Color.TRANSPARENT
 @export var buildable_highlight_color: Color = Color(0.8, 0.8, 0.8, 0.35)
 @export var queen_color: Color = Color("#f2c14e")

--- a/resources/GridConfig.tres
+++ b/resources/GridConfig.tres
@@ -4,8 +4,8 @@
 
 [resource]
 script = ExtResource("1_lm42f")
-radius = 3
-cell_size = 52.0
+radius = 6
+cell_size = 41.6
 cell_color = Color(0, 0, 0, 0)
 queen_color = Color(0.94902, 0.756863, 0.305882, 1)
 cursor_color = Color(0.976471, 0.976471, 1, 0.6)

--- a/scripts/grid/HexGrid.gd
+++ b/scripts/grid/HexGrid.gd
@@ -97,6 +97,8 @@ func move_cursor(delta: Vector2i) -> void:
     var target := _cursor_axial + delta
     if not is_within_grid(target):
         return
+    if not _is_cursor_target_allowed(target):
+        return
     _cursor_axial = target
     _update_cursor_position()
 
@@ -122,6 +124,22 @@ func is_within_grid(axial: Vector2i) -> bool:
     if not _ensure_grid_config():
         return false
     return Coord.axial_distance(Vector2i.ZERO, axial) <= grid_config.radius
+
+func _is_cursor_target_allowed(axial: Vector2i) -> bool:
+    if not _ensure_grid_config():
+        return false
+
+    if not _cell_states.has(axial):
+        return false
+
+    var data: CellData = _cell_states[axial]
+    if data.cell_type != CellType.Type.EMPTY:
+        return true
+
+    if grid_config.allow_isolated_builds:
+        return true
+
+    return is_build_adjacent_to_existing(axial.x, axial.y)
 
 func axial_to_world(axial: Vector2i) -> Vector2:
     if not _ensure_grid_config():


### PR DESCRIPTION
## Summary
- double the grid radius and reduce the default cell size to shrink each hex
- limit cursor movement to built or buildable cells so the highlight stays on actionable tiles

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfb4367a348322b2f7c0c55377f2c6