### PR TITLE
Recenter build palette grid layout

### DIFF
--- a/scenes/BuildPalette.tscn
+++ b/scenes/BuildPalette.tscn
@@ -3,15 +3,15 @@
 [ext_resource type="Script" path="res://scripts/ui/BuildPalette.gd" id="1_5ux0s"]
 
 [node name="BuildPalette" type="Control"]
-anchors_preset = 1
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
-offset_left = 16.0
-offset_top = 16.0
-offset_right = 416.0
-offset_bottom = 144.0
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -200.0
+offset_top = -140.0
+offset_right = 200.0
+offset_bottom = 140.0
 visible = false
 script = ExtResource("1_5ux0s")
 
@@ -21,6 +21,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 offset_right = 0.0
 offset_bottom = 0.0
+self_modulate = Color(1, 1, 1, 0.8)
 
 [node name="Margin" type="MarginContainer" parent="Panel"]
 anchors_preset = 15
@@ -44,6 +45,8 @@ text = "Build Palette"
 vertical_alignment = 1
 horizontal_alignment = 1
 
-[node name="Items" type="HBoxContainer" parent="Panel/Margin/VBox"]
+[node name="Items" type="GridContainer" parent="Panel/Margin/VBox"]
 size_flags_vertical = 3
-custom_constants/separation = 16
+columns = 3
+theme_override_constants/h_separation = 16
+theme_override_constants/v_separation = 12

--- a/scripts/core/CellType.gd
+++ b/scripts/core/CellType.gd
@@ -16,12 +16,12 @@ enum Type {
 
 static func buildable_types() -> Array[int]:
     return [
+        Type.GATHERING,
         Type.WAX,
         Type.VAT,
-        Type.STORAGE,
-        Type.GATHERING,
         Type.GUARD,
         Type.HALL,
+        Type.STORAGE,
     ]
 
 static func to_display_name(cell_type: int) -> String:

--- a/scripts/ui/BuildPalette.gd
+++ b/scripts/ui/BuildPalette.gd
@@ -9,7 +9,7 @@ const PaletteState := preload("res://scripts/input/PaletteState.gd")
 @export var header: String = "Build Palette"
 
 @onready var _title_label: Label = $Panel/Margin/VBox/Title
-@onready var _items_container: HBoxContainer = $Panel/Margin/VBox/Items
+@onready var _items_container: GridContainer = $Panel/Margin/VBox/Items
 
 var _palette_state: PaletteState
 var _labels: Dictionary = {}
@@ -40,6 +40,7 @@ func _create_labels() -> void:
         label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
         label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
         label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        label.size_flags_vertical = Control.SIZE_EXPAND_FILL
         _items_container.add_child(label)
         _labels[cell_type] = label
     _refresh_selection_visuals(_palette_state.get_selected_type())


### PR DESCRIPTION
## Summary
- Center the build palette on screen and soften the panel background with light transparency
- Present build options in a 3x2 grid and ensure labels expand to fill their cells
- Reorder buildable cell types to match the new grid layout sequence

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dfb9ea37888322b01bced0734aff36