### PR TITLE
Fix ResourceManager warnings

### DIFF
--- a/scripts/core/ResourceManager.gd
+++ b/scripts/core/ResourceManager.gd
@@ -1,6 +1,5 @@
 extends Node
 ## Tracks resource balances and build costs for specialized cells.
-class_name ResourceManager
 
 const CellType := preload("res://scripts/core/CellType.gd")
 
@@ -118,9 +117,10 @@ func _read_json(path: String, fallback: Dictionary) -> Dictionary:
     if error != OK:
         push_warning("Failed to parse %s; using defaults" % path)
         return fallback.duplicate(true)
-    var data := json.data
-    if typeof(data) != TYPE_DICTIONARY:
+    var raw_data: Variant = json.data
+    if typeof(raw_data) != TYPE_DICTIONARY:
         return fallback.duplicate(true)
+    var data: Dictionary = raw_data as Dictionary
     return data
 
 func _write_json(path: String, data: Dictionary) -> void:


### PR DESCRIPTION
## Summary
- remove the `class_name` declaration from the autoloaded ResourceManager script to avoid the name collision warning
- explicitly cast parsed JSON data to a Dictionary to prevent Variant inference warnings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfbc7d0c7c8322aaa93ad6258f4e62