### PR TITLE
Center build palette menu

### DIFF
--- a/scripts/ui/BuildPalette.gd
+++ b/scripts/ui/BuildPalette.gd
@@ -10,6 +10,7 @@ const PaletteState := preload("res://scripts/input/PaletteState.gd")
 
 @onready var _title_label: Label = $Panel/Margin/VBox/Title
 @onready var _items_container: GridContainer = $Panel/Margin/VBox/Items
+@onready var _viewport: Viewport = get_viewport()
 
 var _palette_state: PaletteState
 var _labels: Dictionary = {}
@@ -24,6 +25,10 @@ func _ready() -> void:
     _title_label.text = header
     _create_labels()
     visible = false
+
+    if _viewport:
+        _viewport.connect("size_changed", Callable(self, "_center_on_screen"))
+    call_deferred("_center_on_screen")
 
     _palette_state.connect("palette_opened", Callable(self, "_on_palette_opened"))
     _palette_state.connect("palette_closed", Callable(self, "_on_palette_closed"))
@@ -78,3 +83,9 @@ func _refresh_in_hand_visuals(in_hand_type) -> void:
             label.text = "%s *" % base_name
         else:
             label.text = base_name
+
+func _center_on_screen() -> void:
+    if not _viewport:
+        return
+    var viewport_size := _viewport.get_visible_rect().size
+    position = viewport_size * 0.5 - size * 0.5


### PR DESCRIPTION
## Summary
- center the build palette UI based on the current viewport size
- keep the palette centered when the window is resized

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfbc44c9b48322be4a65f06c0b8c84