### PR TITLE
Fix EggManager singleton conflict

### DIFF
--- a/scripts/core/EggManager.gd
+++ b/scripts/core/EggManager.gd
@@ -1,5 +1,4 @@
 extends Node
-class_name EggManager
 
 signal eggs_changed(current: int)
 signal egg_assigned(q: int, r: int)


### PR DESCRIPTION
## Summary
- remove the `class_name` declaration from the autoloaded EggManager to avoid hiding the singleton

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0ffc5944c83229e9e4e013fb3417e