### PR TITLE
Implement bee management and roster assignment flow

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,7 @@ run/main_scene="res://scenes/Main.tscn"
 [autoload]
 ResourceManager="*res://scripts/core/ResourceManager.gd"
 EggManager="*res://scripts/core/EggManager.gd"
+BeeManager="*res://scripts/core/BeeManager.gd"
 
 [input]
 ui_accept={"deadzone":0.5,"events":[{"type":"key","keycode":32,"physical_keycode":32}]}

--- a/resources/GridConfig.gd
+++ b/resources/GridConfig.gd
@@ -19,6 +19,8 @@ const CellType := preload("res://scripts/core/CellType.gd")
 @export var brood_progress_ring_width: float = 2.0
 @export var brood_progress_ring_color: Color = Color(1, 1, 1, 0.9)
 @export var brood_damaged_tint: Color = Color(1.0, 0.7, 0.4, 1.0)
+@export var brood_spent_tint: Color = Color(1.0, 0.9, 0.7, 1.0)
+@export var assignment_highlight_color: Color = Color(1, 1, 1, 0.25)
 @export var allow_isolated_builds: bool = false
 @export var allow_free_builds: bool = false
 

--- a/resources/GridConfig.tres
+++ b/resources/GridConfig.tres
@@ -18,6 +18,8 @@ brood_hatch_seconds = 10.0
 brood_progress_ring_width = 2.0
 brood_progress_ring_color = Color(1, 1, 1, 0.9)
 brood_damaged_tint = Color(1, 0.7, 0.4, 1)
+brood_spent_tint = Color(1, 0.933333, 0.8, 1)
+assignment_highlight_color = Color(1, 1, 1, 0.25)
 type_colors = {
 0: Color(0.94902, 0.756863, 0.305882, 1),
 1: Color(0.964706, 0.827451, 0.396078, 1),

--- a/scenes/BeeRoster.tscn
+++ b/scenes/BeeRoster.tscn
@@ -1,0 +1,70 @@
+[gd_scene load_steps=2 format=3 uid="uid://beeroster"]
+
+[ext_resource type="Script" path="res://scripts/ui/BeeRoster.gd" id="1_g1x06"]
+
+[node name="BeeRoster" type="Control"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -210.0
+offset_top = -190.0
+offset_right = 210.0
+offset_bottom = 190.0
+pivot_offset = Vector2(0, 0)
+visible = false
+script = ExtResource("1_g1x06")
+
+[node name="Panel" type="Panel" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
+
+[node name="Margin" type="MarginContainer" parent="Panel"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 12.0
+offset_top = 12.0
+offset_right = -12.0
+offset_bottom = -12.0
+
+[node name="VBox" type="VBoxContainer" parent="Panel/Margin"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Title" type="Label" parent="Panel/Margin/VBox"]
+text = "Bee Roster"
+horizontal_alignment = 1
+
+[node name="Instructions" type="Label" parent="Panel/Margin/VBox"]
+text = "Tab to toggle • ↑/↓ select • Space choose/assign • Z cancel/unassign"
+custom_minimum_size = Vector2(0, 24)
+vertical_alignment = 1
+horizontal_alignment = 1
+
+[node name="BeeList" type="ItemList" parent="Panel/Margin/VBox"]
+custom_minimum_size = Vector2(0, 170)
+size_flags_vertical = 3
+select_mode = 1
+allow_rmb_select = false
+
+[node name="SpecLabel" type="Label" parent="Panel/Margin/VBox"]
+text = "Specialisation: —"
+vertical_alignment = 1
+horizontal_alignment = 1
+custom_minimum_size = Vector2(0, 24)
+
+[node name="Status" type="Label" parent="Panel/Margin/VBox"]
+text = ""
+vertical_alignment = 1
+horizontal_alignment = 1
+custom_minimum_size = Vector2(0, 20)

--- a/scenes/HexCell.tscn
+++ b/scenes/HexCell.tscn
@@ -9,8 +9,20 @@ script = ExtResource("1_9ocxy")
 color = Color(0.952941, 0.905882, 0.780392, 1)
 texture = null
 
+[node name="AssignmentHighlight" type="Polygon2D" parent="."]
+visible = false
+color = Color(1, 1, 1, 0.25)
+z_index = -1
+texture = null
+
 [node name="ReadyBadge" type="Polygon2D" parent="."]
 visible = false
 color = Color(1, 0.972549, 0.454902, 1)
 z_index = 1
+texture = null
+
+[node name="BeeBadge" type="Polygon2D" parent="."]
+visible = false
+color = Color(0.968627, 0.866667, 0.203922, 1)
+z_index = 2
 texture = null

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=6 format=3 uid="uid://main"]
+[gd_scene load_steps=7 format=3 uid="uid://main"]
 
 [ext_resource type="PackedScene" path="res://scenes/HexGrid.tscn" id="1_kg8yr"]
 [ext_resource type="Script" path="res://scripts/input/InputController.gd" id="2_buqfh"]
 [ext_resource type="Script" path="res://scripts/Main.gd" id="3_p3b4o"]
 [ext_resource type="Script" path="res://scripts/input/PaletteState.gd" id="4_k4cvo"]
 [ext_resource type="PackedScene" path="res://scenes/BuildPalette.tscn" id="5_sef0j"]
+[ext_resource type="PackedScene" path="res://scenes/BeeRoster.tscn" id="6_m6edk"]
 
 [node name="Main" type="Node2D"]
 script = ExtResource("3_p3b4o")
@@ -30,3 +31,5 @@ hex_grid_path = NodePath("../HexGrid")
 script = ExtResource("4_k4cvo")
 
 [node name="BuildPalette" parent="." instance=ExtResource("5_sef0j")]
+
+[node name="BeeRoster" parent="." instance=ExtResource("6_m6edk")]

--- a/scripts/core/BeeManager.gd
+++ b/scripts/core/BeeManager.gd
@@ -1,0 +1,182 @@
+extends Node
+## Central manager for all bee entities. Responsible for tracking their
+## state, specialisations, and assignments to cells.
+class_name BeeManager
+
+signal bee_spawned(bee_id: int)
+signal bee_assigned(bee_id: int, q: int, r: int)
+signal bee_unassigned(bee_id: int)
+signal bee_specialisation_changed(bee_id: int, spec: String)
+
+const CellType := preload("res://scripts/core/CellType.gd")
+
+const STATE_UNASSIGNED := "UNASSIGNED"
+const STATE_ASSIGNED := "ASSIGNED"
+
+const SPECIALISATIONS := [
+    "GATHER",
+    "BREWER",
+    "CONSTRUCTION",
+    "GUARD",
+    "ARCANIST",
+]
+
+var _next_bee_id: int = 1
+var _bees: Dictionary = {}
+var _cell_assignments: Dictionary = {}
+var _hex_grid: Node = null
+
+func register_hex_grid(grid: Node) -> void:
+    _hex_grid = grid
+
+func spawn_bee(origin: Vector2i) -> int:
+    var bee_id := _next_bee_id
+    _next_bee_id += 1
+    var bee_data := {
+        "id": bee_id,
+        "state": STATE_UNASSIGNED,
+        "specialisation": SPECIALISATIONS[0],
+        "assigned_cell": null,
+        "origin_brood": origin,
+    }
+    _bees[bee_id] = bee_data
+    print("[Bees] Hatch complete at (%d,%d) -> Bee #%d spawned (%s)." % [origin.x, origin.y, bee_id, STATE_UNASSIGNED])
+    emit_signal("bee_spawned", bee_id)
+    return bee_id
+
+func set_specialisation(bee_id: int, spec: String) -> void:
+    if not _bees.has(bee_id):
+        return
+    var normalised := spec.upper()
+    if not SPECIALISATIONS.has(normalised):
+        return
+    var bee := _bees[bee_id]
+    if bee["specialisation"] == normalised:
+        return
+    bee["specialisation"] = normalised
+    _bees[bee_id] = bee
+    emit_signal("bee_specialisation_changed", bee_id, normalised)
+
+func assign_to_cell(bee_id: int, q: int, r: int) -> bool:
+    if not _bees.has(bee_id):
+        return false
+    if _hex_grid == null:
+        push_warning("BeeManager has no HexGrid registered; cannot assign bees.")
+        return false
+    var bee := _bees[bee_id]
+    var spec: String = bee["specialisation"]
+    var axial := Vector2i(q, r)
+
+    if spec == "GATHER":
+        print("[Bees] Bee #%d cannot be assigned yet: Gathering roles are virtual." % bee_id)
+        return false
+
+    var cap := _hex_grid.get_bee_cap(q, r)
+    if cap <= 0:
+        var cell_type := _hex_grid.get_cell_type(q, r)
+        print("[Bees] Bee #%d cannot enter %s at (%d,%d): no capacity." % [
+            bee_id,
+            CellType.to_display_name(cell_type),
+            q,
+            r,
+        ])
+        return false
+
+    var allowed_types: Array = _hex_grid.get_cell_types_for_specialisation(spec)
+    var cell_type: int = _hex_grid.get_cell_type(q, r)
+    if allowed_types.is_empty() or not allowed_types.has(cell_type):
+        print("[Bees] Bee #%d with specialisation %s cannot work in %s." % [
+            bee_id,
+            spec,
+            CellType.to_display_name(cell_type),
+        ])
+        return false
+
+    var occupants: Array = _cell_assignments.get(axial, [])
+    if bee["state"] == STATE_ASSIGNED:
+        var previous: Vector2i = bee["assigned_cell"]
+        if previous == axial:
+            return true
+        _remove_bee_from_cell(previous, bee_id)
+        occupants = _cell_assignments.get(axial, [])
+
+    if occupants.size() >= cap:
+        print("[Bees] %s at (%d,%d) is already at capacity." % [
+            CellType.to_display_name(cell_type),
+            q,
+            r,
+        ])
+        return false
+
+    occupants.append(bee_id)
+    _cell_assignments[axial] = occupants
+    bee["state"] = STATE_ASSIGNED
+    bee["assigned_cell"] = axial
+    _bees[bee_id] = bee
+    emit_signal("bee_assigned", bee_id, q, r)
+    return true
+
+func unassign(bee_id: int) -> void:
+    if not _bees.has(bee_id):
+        return
+    var bee := _bees[bee_id]
+    if bee["state"] != STATE_ASSIGNED:
+        return
+    var previous: Vector2i = bee["assigned_cell"]
+    _remove_bee_from_cell(previous, bee_id)
+    bee["state"] = STATE_UNASSIGNED
+    bee["assigned_cell"] = null
+    _bees[bee_id] = bee
+    emit_signal("bee_unassigned", bee_id)
+
+func list_bees(filter: String = "ALL") -> Array:
+    var ids := _bees.keys()
+    ids.sort_custom(Callable(self, "_sort_ids"))
+    var result: Array = []
+    for id_value in ids:
+        var bee := _bees[id_value]
+        if filter == STATE_UNASSIGNED and bee["state"] != STATE_UNASSIGNED:
+            continue
+        if filter == STATE_ASSIGNED and bee["state"] != STATE_ASSIGNED:
+            continue
+        result.append(bee.duplicate())
+    return result
+
+func get_bee(bee_id: int) -> Dictionary:
+    if not _bees.has(bee_id):
+        return {}
+    return _bees[bee_id].duplicate()
+
+func get_bee_count_for_cell(axial: Vector2i) -> int:
+    var occupants: Array = _cell_assignments.get(axial, [])
+    return occupants.size()
+
+func get_bees_for_cell(axial: Vector2i) -> Array:
+    var occupants: Array = _cell_assignments.get(axial, [])
+    return occupants.duplicate()
+
+func _remove_bee_from_cell(axial: Vector2i, bee_id: int) -> void:
+    if axial == null:
+        return
+    if not _cell_assignments.has(axial):
+        return
+    var occupants: Array = _cell_assignments[axial]
+    occupants.erase(bee_id)
+    if occupants.is_empty():
+        _cell_assignments.erase(axial)
+    else:
+        _cell_assignments[axial] = occupants
+
+func _sort_ids(a, b) -> bool:
+    return int(a) < int(b)
+
+func consume_bee_data_snapshot() -> Dictionary:
+    return {
+        "bees": _bees.duplicate(true),
+        "assignments": _cell_assignments.duplicate(true),
+    }
+
+func get_cells_for_specialisation(spec: String) -> Array:
+    if _hex_grid == null:
+        return []
+    return _hex_grid.get_cells_accepting(spec)

--- a/scripts/input/InputController.gd
+++ b/scripts/input/InputController.gd
@@ -3,13 +3,16 @@ extends Node
 ## Handles keyboard input and forwards navigation and build commands.
 @export var hex_grid_path: NodePath
 @export var palette_state_path: NodePath
+@export var bee_roster_path: NodePath
 
 const CellType := preload("res://scripts/core/CellType.gd")
 const HexGrid := preload("res://scripts/grid/HexGrid.gd")
 const PaletteState := preload("res://scripts/input/PaletteState.gd")
+const BeeRoster := preload("res://scripts/ui/BeeRoster.gd")
 
 var _hex_grid: HexGrid
 var _palette_state: PaletteState
+var _bee_roster: BeeRoster
 var _pending_build_axial: Vector2i = Vector2i.ZERO
 var _has_pending_build: bool = false
 
@@ -31,20 +34,47 @@ func _ready() -> void:
     _palette_state = get_node_or_null(palette_state_path)
     if not _palette_state:
         push_warning("InputController could not find PaletteState node at %s" % palette_state_path)
+    if bee_roster_path.is_empty():
+        bee_roster_path = NodePath("../BeeRoster")
+    _bee_roster = get_node_or_null(bee_roster_path)
+    if not _bee_roster:
+        push_warning("InputController could not find BeeRoster node at %s" % bee_roster_path)
 
 func _unhandled_input(event: InputEvent) -> void:
     if not _hex_grid:
         return
 
     if event is InputEventKey and event.pressed and not event.echo:
+        if event.physical_keycode == KEY_TAB:
+            if _bee_roster:
+                if _bee_roster.is_open():
+                    _bee_roster.close()
+                else:
+                    if _palette_state and _palette_state.is_open:
+                        _palette_state.close()
+                    _bee_roster.open()
+            get_viewport().set_input_as_handled()
+            return
         if event.physical_keycode == KEY_Z:
-            if _palette_state:
-                if _palette_state.is_open:
-                    _palette_state.close()
-                _has_pending_build = false
-                _pending_build_axial = Vector2i.ZERO
-                if _palette_state.has_in_hand():
-                    _palette_state.clear_in_hand()
+            if not (_bee_roster and _bee_roster.is_open()):
+                if _palette_state:
+                    if _palette_state.is_open:
+                        _palette_state.close()
+                    _has_pending_build = false
+                    _pending_build_axial = Vector2i.ZERO
+                    if _palette_state.has_in_hand():
+                        _palette_state.clear_in_hand()
+                get_viewport().set_input_as_handled()
+                return
+
+    if _bee_roster and _bee_roster.is_open():
+        var roster_handled := _bee_roster.handle_input(event)
+        if _bee_roster.consume_assignment_request():
+            var axial := _hex_grid.get_cursor_axial()
+            _bee_roster.try_assign_to_cell(axial)
+            get_viewport().set_input_as_handled()
+            return
+        if roster_handled:
             get_viewport().set_input_as_handled()
             return
 
@@ -72,6 +102,11 @@ func _unhandled_input(event: InputEvent) -> void:
         return
 
     if event.is_action_pressed("ui_accept"):
+        if _bee_roster and _bee_roster.is_assignment_armed():
+            var target := _hex_grid.get_cursor_axial()
+            _bee_roster.try_assign_to_cell(target)
+            get_viewport().set_input_as_handled()
+            return
         if _palette_state:
             _pending_build_axial = _hex_grid.get_cursor_axial()
             _has_pending_build = true

--- a/scripts/ui/BeeRoster.gd
+++ b/scripts/ui/BeeRoster.gd
@@ -1,0 +1,352 @@
+extends Control
+## Keyboard-driven roster for managing bees and their assignments.
+class_name BeeRoster
+
+const CellType := preload("res://scripts/core/CellType.gd")
+
+const SPECIALISATIONS := [
+    "GATHER",
+    "BREWER",
+    "CONSTRUCTION",
+    "GUARD",
+    "ARCANIST",
+]
+
+@export var hex_grid_path: NodePath
+
+@onready var _bee_list: ItemList = $Panel/Margin/VBox/BeeList
+@onready var _spec_label: Label = $Panel/Margin/VBox/SpecLabel
+@onready var _status_label: Label = $Panel/Margin/VBox/Status
+
+var _hex_grid: Node = null
+var _is_open := false
+var _bee_ids: Array[int] = []
+var _selected_bee_id: int = -1
+var _spec_picker_active := false
+var _spec_picker_index := 0
+var _pending_assignment := false
+var _assignment_armed := false
+
+func _ready() -> void:
+    visible = false
+    if hex_grid_path.is_empty():
+        hex_grid_path = NodePath("../HexGrid")
+    _hex_grid = get_node_or_null(hex_grid_path)
+    _bee_list.item_selected.connect(_on_item_selected)
+    _bee_list.multi_selected.connect(_on_item_selected)
+    _connect_bee_signals()
+
+func open() -> void:
+    _is_open = true
+    visible = true
+    _spec_picker_active = false
+    _pending_assignment = false
+    _refresh_roster()
+    _set_status("")
+    _update_assignment_highlight()
+
+func close() -> void:
+    _is_open = false
+    visible = false
+    _spec_picker_active = false
+    _pending_assignment = false
+    if _hex_grid:
+        _hex_grid.clear_assignment_highlights()
+
+func is_open() -> bool:
+    return _is_open
+
+func handle_input(event: InputEvent) -> bool:
+    if not _is_open:
+        return false
+    if not (event is InputEventKey and event.pressed and not event.echo):
+        return false
+    var key := event.physical_keycode
+    if _spec_picker_active:
+        if key == KEY_LEFT:
+            _cycle_spec(-1)
+            return true
+        if key == KEY_RIGHT:
+            _cycle_spec(1)
+            return true
+        if key == KEY_SPACE:
+            _confirm_spec()
+            return true
+        if key == KEY_Z:
+            _cancel_spec_picker()
+            return true
+        return false
+
+    match key:
+        KEY_UP:
+            _move_selection(-1)
+            return true
+        KEY_DOWN:
+            _move_selection(1)
+            return true
+        KEY_SPACE:
+            if _assignment_armed and _selected_bee_id != -1:
+                _pending_assignment = true
+                _assignment_armed = false
+                return false
+            _begin_spec_picker()
+            return true
+        KEY_Z:
+            return _handle_unassign()
+    return false
+
+func consume_assignment_request() -> bool:
+    var requested := _pending_assignment
+    _pending_assignment = false
+    return requested
+
+func try_assign_to_cell(axial: Vector2i) -> bool:
+    if _selected_bee_id == -1:
+        _set_status("Select a bee first.")
+        return false
+    if not Engine.has_singleton("BeeManager"):
+        _set_status("Bee manager unavailable.")
+        return false
+    var bee := BeeManager.get_bee(_selected_bee_id)
+    if bee.is_empty():
+        _set_status("Bee data unavailable.")
+        _assignment_armed = false
+        return false
+    var spec: String = bee.get("specialisation", "GATHER")
+    if spec == "GATHER":
+        _set_status("Gatherers await future field jobs; pick another specialisation.")
+        _assignment_armed = false
+        _update_assignment_highlight()
+        return false
+    if _hex_grid:
+        var cell_type := _hex_grid.get_cell_type(axial.x, axial.y)
+        var cap := _hex_grid.get_bee_cap(axial.x, axial.y)
+        if cap <= 0:
+            _set_status("%s cannot house bees." % CellType.to_display_name(cell_type))
+            _assignment_armed = false
+            _update_assignment_highlight()
+            return false
+        var allowed: Array = _hex_grid.get_cell_types_for_specialisation(spec)
+        if allowed.is_empty() or not allowed.has(cell_type):
+            _set_status("%s bees cannot work in %s." % [_format_spec(spec), CellType.to_display_name(cell_type)])
+            _assignment_armed = false
+            _update_assignment_highlight()
+            return false
+        if _hex_grid.get_bee_count(axial.x, axial.y) >= cap:
+            _set_status("%s at (%d,%d) is already full." % [CellType.to_display_name(cell_type), axial.x, axial.y])
+            _assignment_armed = false
+            _update_assignment_highlight()
+            return false
+    var success := BeeManager.assign_to_cell(_selected_bee_id, axial.x, axial.y)
+    if success:
+        _set_status("Bee #%d assigned to (%d,%d)." % [_selected_bee_id, axial.x, axial.y])
+    else:
+        _set_status("Assignment failed.")
+    _assignment_armed = false
+    _update_assignment_highlight()
+    return success
+
+func get_selected_bee_id() -> int:
+    return _selected_bee_id
+
+func is_assignment_armed() -> bool:
+    return _assignment_armed and _selected_bee_id != -1
+
+func _connect_bee_signals() -> void:
+    if not Engine.has_singleton("BeeManager"):
+        return
+    if not BeeManager.bee_spawned.is_connected(_on_bee_list_changed):
+        BeeManager.bee_spawned.connect(_on_bee_list_changed)
+    if not BeeManager.bee_assigned.is_connected(_on_bee_list_changed):
+        BeeManager.bee_assigned.connect(_on_bee_list_changed)
+    if not BeeManager.bee_unassigned.is_connected(_on_bee_list_changed):
+        BeeManager.bee_unassigned.connect(_on_bee_list_changed)
+    if not BeeManager.bee_specialisation_changed.is_connected(_on_bee_list_changed):
+        BeeManager.bee_specialisation_changed.connect(_on_bee_list_changed)
+
+func _on_bee_list_changed(_a = null, _b = null, _c = null) -> void:
+    _refresh_roster()
+    if _is_open:
+        _update_assignment_highlight()
+
+func _refresh_roster() -> void:
+    _bee_list.clear()
+    _bee_ids.clear()
+    if not Engine.has_singleton("BeeManager"):
+        _selected_bee_id = -1
+        _spec_label.text = "Specialisation: —"
+        return
+    var bees := BeeManager.list_bees()
+    var previous_id := _selected_bee_id
+    for bee in bees:
+        var bee_id: int = bee.get("id", 0)
+        _bee_ids.append(bee_id)
+        var state: String = bee.get("state", "UNASSIGNED")
+        var spec: String = bee.get("specialisation", "GATHER")
+        var assigned_cell = bee.get("assigned_cell")
+        var location := "Unassigned"
+        if state == BeeManager.STATE_ASSIGNED and typeof(assigned_cell) == TYPE_VECTOR2I:
+            var coords: Vector2i = assigned_cell
+            location = "(%d,%d)" % [coords.x, coords.y]
+        var label := "Bee #%d  %s  [%s]  %s" % [bee_id, state.capitalize(), _format_spec(spec), location]
+        var index := _bee_list.add_item(label)
+        if state == BeeManager.STATE_ASSIGNED:
+            _bee_list.set_item_custom_fg_color(index, Color(0.9, 0.85, 0.6, 1.0))
+    if _bee_ids.is_empty():
+        _selected_bee_id = -1
+        _spec_label.text = "Specialisation: —"
+        _assignment_armed = false
+        return
+    var selection_changed := true
+    if previous_id != -1 and _bee_ids.has(previous_id):
+        _selected_bee_id = previous_id
+        selection_changed = false
+    else:
+        _selected_bee_id = _bee_ids[0]
+        selection_changed = true
+    var selected_index := _bee_ids.find(_selected_bee_id)
+    if selected_index >= 0:
+        _bee_list.select(selected_index)
+        _bee_list.ensure_current_is_visible()
+    if selection_changed:
+        _assignment_armed = false
+    _update_selected_bee_info()
+
+func _move_selection(delta: int) -> void:
+    if _bee_ids.is_empty():
+        return
+    var index := _bee_ids.find(_selected_bee_id)
+    if index == -1:
+        index = 0
+    index = clamp(index + delta, 0, _bee_ids.size() - 1)
+    _bee_list.select(index)
+    _bee_list.ensure_current_is_visible()
+    _selected_bee_id = _bee_ids[index]
+    if _spec_picker_active:
+        _cancel_spec_picker()
+    _assignment_armed = false
+    _update_selected_bee_info()
+
+func _begin_spec_picker() -> void:
+    if _selected_bee_id == -1:
+        return
+    if not Engine.has_singleton("BeeManager"):
+        return
+    var bee := BeeManager.get_bee(_selected_bee_id)
+    if bee.is_empty():
+        return
+    _spec_picker_active = true
+    _assignment_armed = false
+    var current_spec: String = bee.get("specialisation", "GATHER")
+    _spec_picker_index = max(0, SPECIALISATIONS.find(current_spec))
+    _update_spec_picker_label()
+    _set_status("Pick specialisation: ←/→ change, Space confirm, Z cancel")
+
+func _cycle_spec(delta: int) -> void:
+    _spec_picker_index = (_spec_picker_index + delta) % SPECIALISATIONS.size()
+    if _spec_picker_index < 0:
+        _spec_picker_index = SPECIALISATIONS.size() - 1
+    _update_spec_picker_label()
+
+func _confirm_spec() -> void:
+    if not _spec_picker_active:
+        return
+    if not Engine.has_singleton("BeeManager"):
+        return
+    var spec := SPECIALISATIONS[_spec_picker_index]
+    BeeManager.set_specialisation(_selected_bee_id, spec)
+    _spec_picker_active = false
+    _update_selected_bee_info()
+    if Engine.has_singleton("BeeManager"):
+        var bee := BeeManager.get_bee(_selected_bee_id)
+        _assignment_armed = bee.get("state", "") == BeeManager.STATE_UNASSIGNED
+    if _assignment_armed:
+        _set_status("Specialisation set. Move cursor and press Space to assign.")
+    else:
+        _set_status("Specialisation updated.")
+
+func _cancel_spec_picker() -> void:
+    if not _spec_picker_active:
+        return
+    _spec_picker_active = false
+    _update_selected_bee_info()
+    _set_status("Specialisation unchanged.")
+
+func _handle_unassign() -> bool:
+    if _selected_bee_id == -1:
+        return false
+    if not Engine.has_singleton("BeeManager"):
+        return false
+    var bee := BeeManager.get_bee(_selected_bee_id)
+    if bee.is_empty():
+        return false
+    if bee.get("state", "") != BeeManager.STATE_ASSIGNED:
+        _set_status("Bee is already unassigned.")
+        return true
+    BeeManager.unassign(_selected_bee_id)
+    _assignment_armed = false
+    _set_status("Bee #%d returned to the roster." % _selected_bee_id)
+    return true
+
+func _on_item_selected(index: int, _selected: bool = false) -> void:
+    if index < 0 or index >= _bee_ids.size():
+        return
+    _selected_bee_id = _bee_ids[index]
+    if _spec_picker_active:
+        _cancel_spec_picker()
+    _assignment_armed = false
+    _update_selected_bee_info()
+
+func _update_selected_bee_info() -> void:
+    if not Engine.has_singleton("BeeManager"):
+        _spec_label.text = "Specialisation: —"
+        return
+    var bee := BeeManager.get_bee(_selected_bee_id)
+    if bee.is_empty():
+        _spec_label.text = "Specialisation: —"
+        _assignment_armed = false
+        if _hex_grid:
+            _hex_grid.clear_assignment_highlights()
+        return
+    var spec: String = bee.get("specialisation", "GATHER")
+    _spec_label.text = "Specialisation: %s" % _format_spec(spec)
+    _update_assignment_highlight()
+
+func _update_assignment_highlight() -> void:
+    if not _hex_grid:
+        return
+    if not _is_open:
+        return
+    if _spec_picker_active:
+        var preview_spec := SPECIALISATIONS[_spec_picker_index]
+        _hex_grid.set_assignment_highlights_for_spec(preview_spec)
+        return
+    if _selected_bee_id == -1:
+        _hex_grid.clear_assignment_highlights()
+        return
+    if not Engine.has_singleton("BeeManager"):
+        _hex_grid.clear_assignment_highlights()
+        return
+    var bee := BeeManager.get_bee(_selected_bee_id)
+    if bee.is_empty():
+        _hex_grid.clear_assignment_highlights()
+        return
+    var spec: String = bee.get("specialisation", "GATHER")
+    if spec == "":
+        _hex_grid.clear_assignment_highlights()
+        return
+    _hex_grid.set_assignment_highlights_for_spec(spec)
+
+func _update_spec_picker_label() -> void:
+    var spec := SPECIALISATIONS[_spec_picker_index]
+    _spec_label.text = "Specialisation: ‹ %s ›" % _format_spec(spec)
+    _update_assignment_highlight()
+
+func _format_spec(spec: String) -> String:
+    if spec.is_empty():
+        return "—"
+    return spec.capitalize()
+
+func _set_status(message: String) -> void:
+    _status_label.text = message
+*** End Patch


### PR DESCRIPTION
## Summary
- add a BeeManager autoload to spawn bees, track their data, and expose assignment APIs
- update the hex grid and hex cell visuals to keep brood cells spent, enforce bee capacities, and show assignment highlights/badges
- add a Bee Roster scene with keyboard-driven specialisation/assignment controls and route input through the controller

## Testing
- `godot --headless --quit` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e10133aba08322b69fa2fce9d8e46a