### PR TITLE
Fix BeeRoster script parse error

### DIFF
--- a/scripts/ui/BeeRoster.gd
+++ b/scripts/ui/BeeRoster.gd
@@ -349,4 +349,3 @@ func _format_spec(spec: String) -> String:
 
 func _set_status(message: String) -> void:
     _status_label.text = message
-*** End Patch


### PR DESCRIPTION
## Summary
- remove the stray patch marker left in BeeRoster.gd so the script parses correctly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e10818ba4083229e6ef945e947ce51