### PR TITLE
Add logging for egg and brood lifecycle events

### DIFF
--- a/scripts/core/EggManager.gd
+++ b/scripts/core/EggManager.gd
@@ -11,12 +11,14 @@ func _ready() -> void:
     waiting_brood = []
     eggs = max(0, eggs)
     emit_signal("eggs_changed", eggs)
+    print("[EggManager] Initial egg count: %d." % eggs)
 
 func add_eggs(amount: int) -> void:
     if amount <= 0:
         return
     eggs += amount
     emit_signal("eggs_changed", eggs)
+    print("[EggManager] Eggs added -> %d available." % eggs)
     _dispatch_waiting()
 
 func request_egg(cell_q: int, cell_r: int) -> bool:
@@ -31,6 +33,7 @@ func request_egg(cell_q: int, cell_r: int) -> bool:
     if waiting_brood.find(coord) == -1:
         waiting_brood.append(coord)
         emit_signal("egg_needed", cell_q, cell_r)
+        print("[EggManager] Brood (%d,%d) queued for egg; %d waiting." % [cell_q, cell_r, waiting_brood.size()])
     return false
 
 func refund_egg(count: int = 1) -> void:
@@ -38,6 +41,7 @@ func refund_egg(count: int = 1) -> void:
         return
     eggs += count
     emit_signal("eggs_changed", eggs)
+    print("[EggManager] Egg refund -> %d available." % eggs)
     _dispatch_waiting()
 
 func _dispatch_waiting() -> void:
@@ -47,3 +51,7 @@ func _dispatch_waiting() -> void:
         emit_signal("eggs_changed", eggs)
         emit_signal("egg_assigned", coord.x, coord.y)
         print("[EggManager] Assigned egg to brood (%d,%d)." % [coord.x, coord.y])
+    if waiting_brood.is_empty():
+        print("[EggManager] Dispatch complete -> %d eggs remaining." % eggs)
+    else:
+        print("[EggManager] Dispatch paused -> %d eggs remaining, %d broods still waiting." % [eggs, waiting_brood.size()])

--- a/scripts/grid/HexGrid.gd
+++ b/scripts/grid/HexGrid.gd
@@ -627,6 +627,7 @@ func _begin_brood_incubation(axial: Vector2i, data: CellData, emit_event: bool =
     data.brood_hatch_remaining = grid_config.brood_hatch_seconds
     _active_brood_timers[axial] = true
     set_process(true)
+    print("[Brood] Egg secured at (%d,%d); incubation started (%.1fs)." % [axial.x, axial.y, data.brood_hatch_remaining])
     var cell: HexCell = cells.get(axial)
     if cell:
         cell.set_brood_state(HexCell.BroodState.INCUBATING, true, data.brood_hatch_remaining, grid_config.brood_hatch_seconds)
@@ -641,6 +642,7 @@ func _request_egg_for_brood(axial: Vector2i, data: CellData) -> void:
     if EggManager.request_egg(axial.x, axial.y):
         _begin_brood_incubation(axial, data)
     else:
+        print("[Brood] Brood at (%d,%d) waiting for egg." % [axial.x, axial.y])
         _set_brood_idle(axial, data)
 
 func _on_egg_assigned(q: int, r: int) -> void:
@@ -663,6 +665,7 @@ func _convert_empty_to_brood(axial: Vector2i, data: CellData) -> void:
     data.brood_has_egg = false
     data.brood_hatch_remaining = 0.0
     data.brood_state = HexCell.BroodState.IDLE
+    print("[Brood] New brood cell established at (%d,%d)." % [axial.x, axial.y])
 
     var cell: HexCell = cells.get(axial)
     if cell:


### PR DESCRIPTION
## Summary
- log egg inventory changes, refund handling, and queued brood requests in the egg manager
- add brood lifecycle console messages for new brood cells, incubation starts, and pending egg waits

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e10f1deb508322a080e9a814a332f7