### PR TITLE
Request eggs when player builds brood

### DIFF
--- a/scripts/grid/HexGrid.gd
+++ b/scripts/grid/HexGrid.gd
@@ -278,6 +278,9 @@ func try_place_cell(axial: Vector2i, cell_type: int) -> bool:
             cell.clear_brood_state()
         cell.flash()
 
+    if cell_type == CellType.Type.BROOD:
+        _request_egg_for_brood(axial, data)
+
     recompute_brood_enclosures()
     var changed_types: Array[int] = [cell_type]
     if not _last_brood_created.is_empty():


### PR DESCRIPTION
## Summary
- trigger the egg request logic when the player directly constructs a brood cell so incubation starts immediately
- leave the existing brood visuals intact while ensuring the egg manager queue is used

## Testing
- not run (Godot project)

------
https://chatgpt.com/codex/tasks/task_e_68e1123a238483228197a0f659275737