### PR TITLE
Add debug logging for egg assignment flow

### DIFF
--- a/scripts/core/EggManager.gd
+++ b/scripts/core/EggManager.gd
@@ -25,6 +25,7 @@ func add_eggs(amount: int) -> void:
     _dispatch_waiting()
 
 func request_egg(cell_q: int, cell_r: int) -> bool:
+    print("[EggManager] Egg requested by brood (%d,%d); %d eggs available, %d broods waiting." % [cell_q, cell_r, eggs, waiting_brood.size()])
     if eggs > 0:
         eggs -= 1
         emit_signal("eggs_changed", eggs)
@@ -37,6 +38,7 @@ func request_egg(cell_q: int, cell_r: int) -> bool:
         _enqueue_waiting(coord)
         emit_signal("egg_needed", cell_q, cell_r)
         print("[EggManager] Brood (%d,%d) queued for egg; %d waiting." % [cell_q, cell_r, waiting_brood.size()])
+        _debug_waiting_queue()
     return false
 
 func refund_egg(count: int = 1) -> void:
@@ -48,16 +50,26 @@ func refund_egg(count: int = 1) -> void:
     _dispatch_waiting()
 
 func _dispatch_waiting() -> void:
+    if waiting_brood.is_empty():
+        print("[EggManager] Dispatch check -> queue empty, %d eggs available." % eggs)
+    else:
+        print("[EggManager] Dispatch check -> %d eggs available, queue depth %d." % [eggs, waiting_brood.size()])
+        _debug_waiting_queue()
+
     while eggs > 0 and not waiting_brood.is_empty():
         var coord: Vector2i = waiting_brood.pop_front()
         eggs -= 1
         emit_signal("eggs_changed", eggs)
         emit_signal("egg_assigned", coord.x, coord.y)
         print("[EggManager] Assigned egg to brood (%d,%d)." % [coord.x, coord.y])
+        if not waiting_brood.is_empty():
+            print("[EggManager] %d broods still waiting after dispatch." % waiting_brood.size())
+            _debug_waiting_queue()
     if waiting_brood.is_empty():
         print("[EggManager] Dispatch complete -> %d eggs remaining." % eggs)
     else:
         print("[EggManager] Dispatch paused -> %d eggs remaining, %d broods still waiting." % [eggs, waiting_brood.size()])
+        _debug_waiting_queue()
 
 func set_queen_position(q: int, r: int) -> void:
     queen_position = Vector2i(q, r)
@@ -67,6 +79,15 @@ func set_queen_position(q: int, r: int) -> void:
 func _enqueue_waiting(coord: Vector2i) -> void:
     waiting_brood.append(coord)
     _sort_waiting()
+
+func _debug_waiting_queue() -> void:
+    if waiting_brood.is_empty():
+        print("[EggManager] Waiting queue -> (empty)")
+        return
+    var entries: Array[String] = []
+    for queued in waiting_brood:
+        entries.append("(%d,%d)" % [queued.x, queued.y])
+    print("[EggManager] Waiting queue -> %s" % ", ".join(entries))
 
 func _sort_waiting() -> void:
     if waiting_brood.size() <= 1:

--- a/scripts/grid/HexGrid.gd
+++ b/scripts/grid/HexGrid.gd
@@ -652,6 +652,7 @@ func _request_egg_for_brood(axial: Vector2i, data: CellData) -> void:
     if not Engine.has_singleton("EggManager"):
         _set_brood_idle(axial, data)
         return
+    print("[Brood] Requesting egg for (%d,%d); brood state %s, has_egg=%s." % [axial.x, axial.y, str(data.brood_state), str(data.brood_has_egg)])
     if EggManager.request_egg(axial.x, axial.y):
         _begin_brood_incubation(axial, data)
     else:
@@ -660,15 +661,20 @@ func _request_egg_for_brood(axial: Vector2i, data: CellData) -> void:
 
 func _on_egg_assigned(q: int, r: int) -> void:
     var axial := Vector2i(q, r)
+    print("[Brood] Egg assignment signal received for (%d,%d)." % [q, r])
     if not _cell_states.has(axial):
+        print("[Brood] No cell data for (%d,%d); refunding egg." % [q, r])
         EggManager.refund_egg()
         return
     var data: CellData = _cell_states[axial]
     if data.cell_type != CellType.Type.BROOD:
+        print("[Brood] Cell (%d,%d) not brood (type=%s); refunding egg." % [q, r, str(data.cell_type)])
         EggManager.refund_egg()
         return
     if data.brood_state != HexCell.BroodState.IDLE:
+        print("[Brood] Cell (%d,%d) not idle (state=%s); ignoring assignment." % [q, r, str(data.brood_state)])
         return
+    print("[Brood] Accepting egg assignment at (%d,%d)." % [q, r])
     _begin_brood_incubation(axial, data)
 
 func _convert_empty_to_brood(axial: Vector2i, data: CellData) -> void:


### PR DESCRIPTION
## Summary
- add verbose logging in `EggManager` to surface egg requests, queue state, and dispatch progress
- log brood egg requests and assignment handling paths in `HexGrid` to diagnose hatching issues

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1152f91cc8322bdb26ef5280332ca