### PR TITLE
Implement bee assignment picker and brood hatch conversion

### DIFF
--- a/resources/GridConfig.gd
+++ b/resources/GridConfig.gd
@@ -23,6 +23,8 @@ const CellType := preload("res://scripts/core/CellType.gd")
 @export var assignment_highlight_color: Color = Color(1, 1, 1, 0.25)
 @export var allow_isolated_builds: bool = false
 @export var allow_free_builds: bool = false
+@export var default_bee_cap_per_cell: int = 1
+@export var disallowed_bee_cells: PackedStringArray = PackedStringArray()
 
 func _init() -> void:
     if type_colors.is_empty():

--- a/resources/GridConfig.tres
+++ b/resources/GridConfig.tres
@@ -20,6 +20,8 @@ brood_progress_ring_color = Color(1, 1, 1, 0.9)
 brood_damaged_tint = Color(1, 0.7, 0.4, 1)
 brood_spent_tint = Color(1, 0.933333, 0.8, 1)
 assignment_highlight_color = Color(1, 1, 1, 0.25)
+default_bee_cap_per_cell = 1
+disallowed_bee_cells = []
 type_colors = {
 0: Color(0.94902, 0.756863, 0.305882, 1),
 1: Color(0.964706, 0.827451, 0.396078, 1),

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://main"]
+[gd_scene load_steps=8 format=3 uid="uid://main"]
 
 [ext_resource type="PackedScene" uid="uid://hexgrid" path="res://scenes/HexGrid.tscn" id="1_kg8yr"]
 [ext_resource type="Script" uid="uid://bb7bx1ydmjot5" path="res://scripts/input/InputController.gd" id="2_buqfh"]
@@ -6,6 +6,7 @@
 [ext_resource type="Script" uid="uid://dnikp3jekemme" path="res://scripts/input/PaletteState.gd" id="4_k4cvo"]
 [ext_resource type="PackedScene" uid="uid://buildpalette" path="res://scenes/BuildPalette.tscn" id="5_sef0j"]
 [ext_resource type="PackedScene" uid="uid://beeroster" path="res://scenes/BeeRoster.tscn" id="6_m6edk"]
+[ext_resource type="PackedScene" path="res://scenes/ui/AssignBeePicker.tscn" id="7_9g0d0"]
 
 [node name="Main" type="Node2D"]
 script = ExtResource("3_p3b4o")
@@ -34,4 +35,7 @@ script = ExtResource("4_k4cvo")
 layout_mode = 3
 
 [node name="BeeRoster" parent="." instance=ExtResource("6_m6edk")]
+layout_mode = 3
+
+[node name="AssignBeePicker" parent="." instance=ExtResource("7_9g0d0")]
 layout_mode = 3

--- a/scenes/ui/AssignBeePicker.tscn
+++ b/scenes/ui/AssignBeePicker.tscn
@@ -1,0 +1,61 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/AssignBeePicker.gd" id="1_fi8v3"]
+
+[node name="AssignBeePicker" type="Control"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+position = Vector2(0, 0)
+size = Vector2(260, 220)
+pivot_offset = Vector2(130, 110)
+mouse_filter = 2
+visible = false
+script = ExtResource("1_fi8v3")
+
+[node name="Panel" type="Panel" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -130.0
+offset_top = -110.0
+offset_right = 130.0
+offset_bottom = 110.0
+
+[node name="Margin" type="MarginContainer" parent="Panel"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 12.0
+offset_top = 12.0
+offset_right = -12.0
+offset_bottom = -12.0
+
+[node name="VBox" type="VBoxContainer" parent="Panel/Margin"]
+layout_mode = 2
+
+[node name="Title" type="Label" parent="Panel/Margin/VBox"]
+layout_mode = 2
+text = "Assign Bee"
+align = 1
+
+[node name="BeeList" type="ItemList" parent="Panel/Margin/VBox"]
+layout_mode = 2
+size_flags_vertical = 3
+select_mode = 1
+allow_reselect = true
+
+[node name="Status" type="Label" parent="Panel/Margin/VBox"]
+layout_mode = 2
+text = ""
+
+[node name="Hint" type="Label" parent="Panel/Margin/VBox"]
+layout_mode = 2
+modulate = Color(1, 1, 1, 0.7)
+text = ""
+
+[node name="AutoCloseTimer" type="Timer" parent="."]
+one_shot = true
+wait_time = 0.7

--- a/scripts/core/BeeManager.gd
+++ b/scripts/core/BeeManager.gd
@@ -7,17 +7,16 @@ signal bee_assigned(bee_id: int, q: int, r: int)
 signal bee_unassigned(bee_id: int)
 signal bee_specialisation_changed(bee_id: int, spec: String)
 
-const CellType := preload("res://scripts/core/CellType.gd")
-
 const STATE_UNASSIGNED := "UNASSIGNED"
 const STATE_ASSIGNED := "ASSIGNED"
 
+## Legacy list retained for compatibility with the roster UI.
 const SPECIALISATIONS := [
-	"GATHER",
-	"BREWER",
-	"CONSTRUCTION",
-	"GUARD",
-	"ARCANIST",
+        "GATHER",
+        "BREWER",
+        "CONSTRUCTION",
+        "GUARD",
+        "ARCANIST",
 ]
 
 var _next_bee_id: int = 1
@@ -26,156 +25,157 @@ var _cell_assignments: Dictionary = {}
 var _hex_grid: Node = null
 
 func register_hex_grid(grid: Node) -> void:
-	_hex_grid = grid
+        _hex_grid = grid
 
 func spawn_bee(origin: Vector2i) -> int:
-	var bee_id := _next_bee_id
-	_next_bee_id += 1
-	var bee_data := {
-		"id": bee_id,
-		"state": STATE_UNASSIGNED,
-		"specialisation": SPECIALISATIONS[0],
-		"assigned_cell": null,
-		"origin_brood": origin,
-	}
-	_bees[bee_id] = bee_data
-	print("[Bees] Hatch complete at (%d,%d) -> Bee #%d spawned (%s)." % [origin.x, origin.y, bee_id, STATE_UNASSIGNED])
-	emit_signal("bee_spawned", bee_id)
-	return bee_id
+        var bee_id := _next_bee_id
+        _next_bee_id += 1
+        var bee_data := {
+                "id": bee_id,
+                "state": STATE_UNASSIGNED,
+                "specialisation": SPECIALISATIONS[0],
+                "assigned_cell": null,
+                "origin_brood": origin,
+        }
+        _bees[bee_id] = bee_data
+        emit_signal("bee_spawned", bee_id)
+        return bee_id
+
+func list_unassigned() -> Array[int]:
+        var ids: Array[int] = []
+        for bee_data in _bees.values():
+                if bee_data.get("state", STATE_UNASSIGNED) == STATE_UNASSIGNED:
+                        ids.append(bee_data.get("id", 0))
+        ids.sort()
+        return ids
 
 func set_specialisation(bee_id: int, spec: String) -> void:
-	if not _bees.has(bee_id):
-		return
-	var normalised: String = spec.to_upper()
-	if not SPECIALISATIONS.has(normalised):
-		return
-	var bee: Dictionary = _bees[bee_id]
-	if bee["specialisation"] == normalised:
-		return
-	bee["specialisation"] = normalised
-	_bees[bee_id] = bee
-	emit_signal("bee_specialisation_changed", bee_id, normalised)
+        ## Specialisations are retained only for UI compatibility. They do not
+        ## influence assignment eligibility in the current design, but we keep
+        ## the signal flow intact so the roster can continue to reflect user
+        ## choices.
+        if not _bees.has(bee_id):
+                return
+        var normalised: String = spec.to_upper()
+        if not SPECIALISATIONS.has(normalised):
+                return
+        var bee: Dictionary = _bees[bee_id]
+        if bee.get("specialisation", SPECIALISATIONS[0]) == normalised:
+                return
+        bee["specialisation"] = normalised
+        _bees[bee_id] = bee
+        emit_signal("bee_specialisation_changed", bee_id, normalised)
 
 func assign_to_cell(bee_id: int, q: int, r: int) -> bool:
-	if not _bees.has(bee_id):
-		return false
-	if _hex_grid == null:
-		push_warning("BeeManager has no HexGrid registered; cannot assign bees.")
-		return false
-	var bee: Dictionary = _bees[bee_id]
-	var spec: String = bee["specialisation"]
-	var axial := Vector2i(q, r)
+        if not _bees.has(bee_id):
+                return false
+        if _hex_grid == null:
+                push_warning("BeeManager has no HexGrid registered; cannot assign bees.")
+                return false
+        var bee: Dictionary = _bees[bee_id]
+        var axial := Vector2i(q, r)
 
-	if spec == "GATHER":
-		print("[Bees] Bee #%d cannot be assigned yet: Gathering roles are virtual." % bee_id)
-		return false
+        if not _hex_grid.cell_is_eligible_for_bee(q, r):
+                print("[Bees] Cell (%d,%d) is not eligible for bees." % [q, r])
+                return false
 
-	var cap: int = _hex_grid.get_bee_cap(q, r)
-	if cap <= 0:
-		var cell_type: int = _hex_grid.get_cell_type(q, r)
-		print("[Bees] Bee #%d cannot enter %s at (%d,%d): no capacity." % [
-			bee_id,
-			CellType.to_display_name(cell_type),
-			q,
-			r,
-		])
-		return false
+        var cap: int = _hex_grid.cell_bee_cap(q, r)
+        if cap <= 0:
+                print("[Bees] Cell (%d,%d) cannot host bees (cap=%d)." % [q, r, cap])
+                return false
 
-	var allowed_types: Array = _hex_grid.get_cell_types_for_specialisation(spec)
-	var cell_type: int = _hex_grid.get_cell_type(q, r)
-	if allowed_types.is_empty() or not allowed_types.has(cell_type):
-		print("[Bees] Bee #%d with specialisation %s cannot work in %s." % [
-			bee_id,
-			spec,
-			CellType.to_display_name(cell_type),
-		])
-		return false
+        var occupants: Array = _cell_assignments.get(axial, [])
+        if bee.get("state", STATE_UNASSIGNED) == STATE_ASSIGNED:
+                var previous: Vector2i = bee.get("assigned_cell")
+                if previous == axial:
+                        return true
+                _remove_bee_from_cell(previous, bee_id)
+                occupants = _cell_assignments.get(axial, [])
 
-	var occupants: Array = _cell_assignments.get(axial, [])
-	if bee["state"] == STATE_ASSIGNED:
-		var previous: Vector2i = bee["assigned_cell"]
-		if previous == axial:
-			return true
-		_remove_bee_from_cell(previous, bee_id)
-		occupants = _cell_assignments.get(axial, [])
+        if occupants.size() >= cap:
+                print("[Bees] Cell (%d,%d) has no free bee slots." % [q, r])
+                return false
 
-	if occupants.size() >= cap:
-		print("[Bees] %s at (%d,%d) is already at capacity." % [
-			CellType.to_display_name(cell_type),
-			q,
-			r,
-		])
-		return false
+        occupants.append(bee_id)
+        _cell_assignments[axial] = occupants
+        bee["state"] = STATE_ASSIGNED
+        bee["assigned_cell"] = axial
+        _bees[bee_id] = bee
+        emit_signal("bee_assigned", bee_id, q, r)
+        return true
 
-	occupants.append(bee_id)
-	_cell_assignments[axial] = occupants
-	bee["state"] = STATE_ASSIGNED
-	bee["assigned_cell"] = axial
-	_bees[bee_id] = bee
-	emit_signal("bee_assigned", bee_id, q, r)
-	return true
+func unassign_from_cell(bee_id: int) -> void:
+        if not _bees.has(bee_id):
+                return
+        var bee: Dictionary = _bees[bee_id]
+        if bee.get("state", STATE_UNASSIGNED) != STATE_ASSIGNED:
+                return
+        var previous: Vector2i = bee.get("assigned_cell")
+        _remove_bee_from_cell(previous, bee_id)
+        bee["state"] = STATE_UNASSIGNED
+        bee["assigned_cell"] = null
+        _bees[bee_id] = bee
+        emit_signal("bee_unassigned", bee_id)
 
 func unassign(bee_id: int) -> void:
-	if not _bees.has(bee_id):
-		return
-	var bee: Dictionary = _bees[bee_id]
-	if bee["state"] != STATE_ASSIGNED:
-		return
-	var previous: Vector2i = bee["assigned_cell"]
-	_remove_bee_from_cell(previous, bee_id)
-	bee["state"] = STATE_UNASSIGNED
-	bee["assigned_cell"] = null
-	_bees[bee_id] = bee
-	emit_signal("bee_unassigned", bee_id)
+        ## Backwards-compatible alias.
+        unassign_from_cell(bee_id)
 
 func list_bees(filter: String = "ALL") -> Array:
-	var ids: Array = _bees.keys()
-	ids.sort_custom(Callable(self, "_sort_ids"))
-	var result: Array = []
-	for id_value in ids:
-		var bee: Dictionary = _bees[id_value]
-		if filter == STATE_UNASSIGNED and bee["state"] != STATE_UNASSIGNED:
-			continue
-		if filter == STATE_ASSIGNED and bee["state"] != STATE_ASSIGNED:
-			continue
-		result.append(bee.duplicate())
-	return result
+        var ids: Array = _bees.keys()
+        ids.sort_custom(Callable(self, "_sort_ids"))
+        var result: Array = []
+        for id_value in ids:
+                var bee: Dictionary = _bees[id_value]
+                var state: String = bee.get("state", STATE_UNASSIGNED)
+                if filter == STATE_UNASSIGNED and state != STATE_UNASSIGNED:
+                        continue
+                if filter == STATE_ASSIGNED and state != STATE_ASSIGNED:
+                        continue
+                result.append(bee.duplicate())
+        return result
 
 func get_bee(bee_id: int) -> Dictionary:
-	if not _bees.has(bee_id):
-		return {}
-	return _bees[bee_id].duplicate()
+        if not _bees.has(bee_id):
+                return {}
+        return _bees[bee_id].duplicate()
 
 func get_bee_count_for_cell(axial: Vector2i) -> int:
-	var occupants: Array = _cell_assignments.get(axial, [])
-	return occupants.size()
+        var occupants: Array = _cell_assignments.get(axial, [])
+        return occupants.size()
 
 func get_bees_for_cell(axial: Vector2i) -> Array:
-	var occupants: Array = _cell_assignments.get(axial, [])
-	return occupants.duplicate()
+        var occupants: Array = _cell_assignments.get(axial, [])
+        return occupants.duplicate()
 
-func _remove_bee_from_cell(axial: Vector2i, bee_id: int) -> void:
-	if axial == null:
-		return
-	if not _cell_assignments.has(axial):
-		return
-	var occupants: Array = _cell_assignments[axial]
-	occupants.erase(bee_id)
-	if occupants.is_empty():
-		_cell_assignments.erase(axial)
-	else:
-		_cell_assignments[axial] = occupants
-
-func _sort_ids(a, b) -> bool:
-	return int(a) < int(b)
+func get_last_assigned_bee_for_cell(axial: Vector2i) -> int:
+        var occupants: Array = _cell_assignments.get(axial, [])
+        if occupants.is_empty():
+                return -1
+        return int(occupants.back())
 
 func consume_bee_data_snapshot() -> Dictionary:
-	return {
-		"bees": _bees.duplicate(true),
-		"assignments": _cell_assignments.duplicate(true),
-	}
+        return {
+                "bees": _bees.duplicate(true),
+                "assignments": _cell_assignments.duplicate(true),
+        }
 
-func get_cells_for_specialisation(spec: String) -> Array:
-	if _hex_grid == null:
-		return []
-	return _hex_grid.get_cells_accepting(spec)
+func get_cells_for_specialisation(_spec: String) -> Array:
+        if _hex_grid == null:
+                return []
+        return _hex_grid.get_cells_accepting("")
+
+func _remove_bee_from_cell(axial: Vector2i, bee_id: int) -> void:
+        if axial == null:
+                return
+        if not _cell_assignments.has(axial):
+                return
+        var occupants: Array = _cell_assignments[axial]
+        occupants.erase(bee_id)
+        if occupants.is_empty():
+                _cell_assignments.erase(axial)
+        else:
+                _cell_assignments[axial] = occupants
+
+func _sort_ids(a, b) -> bool:
+        return int(a) < int(b)

--- a/scripts/input/InputController.gd
+++ b/scripts/input/InputController.gd
@@ -4,15 +4,18 @@ extends Node
 @export var hex_grid_path: NodePath
 @export var palette_state_path: NodePath
 @export var bee_roster_path: NodePath
+@export var assign_bee_picker_path: NodePath
 
 const CellType := preload("res://scripts/core/CellType.gd")
 const HexGrid := preload("res://scripts/grid/HexGrid.gd")
 const PaletteState := preload("res://scripts/input/PaletteState.gd")
 const BeeRoster := preload("res://scripts/ui/BeeRoster.gd")
+const AssignBeePicker := preload("res://scripts/ui/AssignBeePicker.gd")
 
 var _hex_grid: HexGrid
 var _palette_state: PaletteState
 var _bee_roster: BeeRoster
+var _assign_picker: AssignBeePicker
 var _pending_build_axial: Vector2i = Vector2i.ZERO
 var _has_pending_build: bool = false
 
@@ -34,43 +37,64 @@ func _ready() -> void:
 	_palette_state = get_node_or_null(palette_state_path)
 	if not _palette_state:
 		push_warning("InputController could not find PaletteState node at %s" % palette_state_path)
-	if bee_roster_path.is_empty():
-		bee_roster_path = NodePath("../BeeRoster")
-	_bee_roster = get_node_or_null(bee_roster_path)
-	if not _bee_roster:
-		push_warning("InputController could not find BeeRoster node at %s" % bee_roster_path)
+        if bee_roster_path.is_empty():
+                bee_roster_path = NodePath("../BeeRoster")
+        _bee_roster = get_node_or_null(bee_roster_path)
+        if not _bee_roster:
+                push_warning("InputController could not find BeeRoster node at %s" % bee_roster_path)
+        if assign_bee_picker_path.is_empty():
+                assign_bee_picker_path = NodePath("../AssignBeePicker")
+        _assign_picker = get_node_or_null(assign_bee_picker_path)
+        if not _assign_picker:
+                push_warning("InputController could not find AssignBeePicker node at %s" % assign_bee_picker_path)
 
 func _unhandled_input(event: InputEvent) -> void:
 	if not _hex_grid:
 		return
 
-	if event is InputEventKey and event.pressed and not event.echo:
-		if event.physical_keycode == KEY_TAB:
-			if _bee_roster:
-				if _bee_roster.is_open():
-					_bee_roster.close()
-				else:
-					if _palette_state and _palette_state.is_open:
-						_palette_state.close()
-					_bee_roster.open()
-			get_viewport().set_input_as_handled()
-			return
-		if event.physical_keycode == KEY_Z:
-			if not (_bee_roster and _bee_roster.is_open()):
-				if _palette_state:
-					if _palette_state.is_open:
-						_palette_state.close()
-					_has_pending_build = false
-					_pending_build_axial = Vector2i.ZERO
-					if _palette_state.has_in_hand():
-						_palette_state.clear_in_hand()
-				get_viewport().set_input_as_handled()
-				return
+        if event is InputEventKey and event.pressed and not event.echo:
+                if _assign_picker and _assign_picker.is_open():
+                        if _assign_picker.handle_input(event):
+                                get_viewport().set_input_as_handled()
+                                return
+                if event.physical_keycode == KEY_TAB:
+                        if _bee_roster:
+                                if _bee_roster.is_open():
+                                        _bee_roster.close()
+                                else:
+                                        if _palette_state and _palette_state.is_open:
+                                                _palette_state.close()
+                                        _bee_roster.open()
+                        get_viewport().set_input_as_handled()
+                        return
+                if event.physical_keycode == KEY_SPACE:
+                        if not (_bee_roster and _bee_roster.is_open()):
+                                if _try_open_assign_picker():
+                                        get_viewport().set_input_as_handled()
+                                        return
+                if event.physical_keycode == KEY_Z:
+                        if not (_bee_roster and _bee_roster.is_open()):
+                                if _assign_picker and _assign_picker.is_open():
+                                        if _assign_picker.handle_input(event):
+                                                get_viewport().set_input_as_handled()
+                                                return
+                                if _try_unassign_current_cell():
+                                        get_viewport().set_input_as_handled()
+                                        return
+                                if _palette_state:
+                                        if _palette_state.is_open:
+                                                _palette_state.close()
+                                        _has_pending_build = false
+                                        _pending_build_axial = Vector2i.ZERO
+                                        if _palette_state.has_in_hand():
+                                                _palette_state.clear_in_hand()
+                                get_viewport().set_input_as_handled()
+                                return
 
-	if _bee_roster and _bee_roster.is_open():
-		var roster_handled := _bee_roster.handle_input(event)
-		if _bee_roster.consume_assignment_request():
-			var axial := _hex_grid.get_cursor_axial()
+        if _bee_roster and _bee_roster.is_open():
+                var roster_handled := _bee_roster.handle_input(event)
+                if _bee_roster.consume_assignment_request():
+                        var axial := _hex_grid.get_cursor_axial()
 			_bee_roster.try_assign_to_cell(axial)
 			get_viewport().set_input_as_handled()
 			return
@@ -101,12 +125,17 @@ func _unhandled_input(event: InputEvent) -> void:
 			return
 		return
 
-	if event.is_action_pressed("ui_accept"):
-		if _bee_roster and _bee_roster.is_assignment_armed():
-			var target := _hex_grid.get_cursor_axial()
-			_bee_roster.try_assign_to_cell(target)
-			get_viewport().set_input_as_handled()
-			return
+        if _assign_picker and _assign_picker.is_open():
+                if _assign_picker.handle_input(event):
+                        get_viewport().set_input_as_handled()
+                        return
+
+        if event.is_action_pressed("ui_accept"):
+                if _bee_roster and _bee_roster.is_assignment_armed():
+                        var target := _hex_grid.get_cursor_axial()
+                        _bee_roster.try_assign_to_cell(target)
+                        get_viewport().set_input_as_handled()
+                        return
 		if _palette_state:
 			_pending_build_axial = _hex_grid.get_cursor_axial()
 			_has_pending_build = true
@@ -115,7 +144,37 @@ func _unhandled_input(event: InputEvent) -> void:
 		return
 
 	for action in MOVE_VECTORS.keys():
-		if event.is_action_pressed(action):
-			_hex_grid.move_cursor(MOVE_VECTORS[action])
-			get_viewport().set_input_as_handled()
-			return
+                if event.is_action_pressed(action):
+                        _hex_grid.move_cursor(MOVE_VECTORS[action])
+                        get_viewport().set_input_as_handled()
+                        return
+
+func _try_open_assign_picker() -> bool:
+        if not _hex_grid or not _assign_picker:
+                return false
+        var axial := _hex_grid.get_cursor_axial()
+        if not _hex_grid.cell_is_eligible_for_bee(axial.x, axial.y):
+                print("[Bees] No slot available at (%d,%d)." % [axial.x, axial.y])
+                return true
+        var cap := _hex_grid.cell_bee_cap(axial.x, axial.y)
+        var used := _hex_grid.cell_bee_count(axial.x, axial.y)
+        if used >= cap:
+                print("[Bees] No slot available at (%d,%d)." % [axial.x, axial.y])
+                return true
+        _assign_picker.open_for_cell(axial)
+        return true
+
+func _try_unassign_current_cell() -> bool:
+        if not _hex_grid:
+                return false
+        var axial := _hex_grid.get_cursor_axial()
+        if _hex_grid.cell_bee_count(axial.x, axial.y) <= 0:
+                return false
+        if not Engine.has_singleton("BeeManager"):
+                return false
+        var bee_id := BeeManager.get_last_assigned_bee_for_cell(axial)
+        if bee_id == -1:
+                return false
+        BeeManager.unassign_from_cell(bee_id)
+        print("[Bees] Bee #%d unassigned from (%d,%d)." % [bee_id, axial.x, axial.y])
+        return true

--- a/scripts/ui/AssignBeePicker.gd
+++ b/scripts/ui/AssignBeePicker.gd
@@ -1,0 +1,177 @@
+extends Control
+## Lightweight modal picker for assigning unassigned bees to a cell.
+class_name AssignBeePicker
+
+@export var empty_close_delay: float = 0.7
+
+@onready var _list: ItemList = $Panel/Margin/VBox/BeeList
+@onready var _status_label: Label = $Panel/Margin/VBox/Status
+@onready var _hint_label: Label = $Panel/Margin/VBox/Hint
+@onready var _timer: Timer = $AutoCloseTimer
+
+var _target_cell: Vector2i = Vector2i.ZERO
+var _bee_ids: Array[int] = []
+var _selected_index: int = 0
+var _is_open := false
+var _close_on_any_input := false
+
+func _ready() -> void:
+        visible = false
+        _timer.one_shot = true
+        _timer.timeout.connect(_on_auto_close_timeout)
+        _connect_bee_signals()
+
+func is_open() -> bool:
+        return _is_open
+
+func open_for_cell(axial: Vector2i) -> void:
+        _target_cell = axial
+        _is_open = true
+        visible = true
+        _close_on_any_input = false
+        _timer.stop()
+        _timer.wait_time = empty_close_delay
+        _populate_bee_list()
+        if _bee_ids.is_empty():
+                _status_label.text = "No bees available"
+                _hint_label.text = ""
+                _close_on_any_input = true
+                _timer.start(empty_close_delay)
+        else:
+                _status_label.text = "Assign to (%d,%d)." % [axial.x, axial.y]
+                _hint_label.text = "↑/↓ select · Space assign · Z cancel"
+                _selected_index = 0
+                _apply_selection()
+
+func close_picker() -> void:
+        if not _is_open:
+                return
+        _is_open = false
+        visible = false
+        _timer.stop()
+        _bee_ids.clear()
+        _list.clear()
+        _status_label.text = ""
+        _hint_label.text = ""
+        _close_on_any_input = false
+
+func handle_input(event: InputEvent) -> bool:
+        if not _is_open:
+                return false
+        if event is InputEventAction and event.pressed:
+                if _close_on_any_input:
+                        close_picker()
+                        return true
+                if event.action == "ui_up":
+                        _move_selection(-1)
+                        return true
+                if event.action == "ui_down":
+                        _move_selection(1)
+                        return true
+                if event.action == "ui_left" or event.action == "ui_right":
+                        return true
+                if event.action == "ui_accept":
+                        return _confirm_selection()
+                if event.action == "ui_cancel":
+                        close_picker()
+                        return true
+        if event is InputEventKey and event.pressed and not event.echo:
+                if _close_on_any_input:
+                        close_picker()
+                        return true
+                match event.physical_keycode:
+                        KEY_UP:
+                                _move_selection(-1)
+                                return true
+                        KEY_DOWN:
+                                _move_selection(1)
+                                return true
+                        KEY_LEFT, KEY_RIGHT:
+                                return true
+                        KEY_SPACE:
+                                return _confirm_selection()
+                        KEY_Z:
+                                close_picker()
+                                return true
+        return false
+
+func _confirm_selection() -> bool:
+        if _bee_ids.is_empty():
+                close_picker()
+                return true
+        if not Engine.has_singleton("BeeManager"):
+                _status_label.text = "Bee manager unavailable."
+                return true
+        var index := clamp(_selected_index, 0, _bee_ids.size() - 1)
+        var bee_id := _bee_ids[index]
+        var success := BeeManager.assign_to_cell(bee_id, _target_cell.x, _target_cell.y)
+        if success:
+                close_picker()
+        else:
+                _status_label.text = "Assignment failed."
+        return true
+
+func _move_selection(delta: int) -> void:
+        if _bee_ids.is_empty():
+                return
+        _selected_index = clamp(_selected_index + delta, 0, _bee_ids.size() - 1)
+        _apply_selection()
+
+func _apply_selection() -> void:
+        if _bee_ids.is_empty():
+                _list.unselect_all()
+                return
+        _selected_index = clamp(_selected_index, 0, _bee_ids.size() - 1)
+        _list.select(_selected_index)
+        _list.ensure_current_is_visible()
+
+func _populate_bee_list() -> void:
+        _list.clear()
+        _bee_ids.clear()
+        if not Engine.has_singleton("BeeManager"):
+                return
+        var ids: Array[int] = BeeManager.list_unassigned()
+        for bee_id in ids:
+                var bee := BeeManager.get_bee(bee_id)
+                var origin := bee.get("origin_brood", Vector2i.ZERO)
+                var origin_text := ""
+                if typeof(origin) == TYPE_VECTOR2I:
+                        origin_text = " (from %d,%d)" % [origin.x, origin.y]
+                var label := "Bee #%d%s" % [bee_id, origin_text]
+                _bee_ids.append(bee_id)
+                _list.add_item(label)
+
+func _on_auto_close_timeout() -> void:
+        close_picker()
+
+func _connect_bee_signals() -> void:
+        if not Engine.has_singleton("BeeManager"):
+                return
+        if not BeeManager.bee_spawned.is_connected(_on_bee_list_changed):
+                BeeManager.bee_spawned.connect(_on_bee_list_changed)
+        if not BeeManager.bee_unassigned.is_connected(_on_bee_list_changed):
+                BeeManager.bee_unassigned.connect(_on_bee_list_changed)
+        if not BeeManager.bee_assigned.is_connected(_on_bee_list_changed):
+                BeeManager.bee_assigned.connect(_on_bee_list_changed)
+
+func _on_bee_list_changed(_a = 0, _b = 0, _c = 0) -> void:
+        if not _is_open:
+                return
+        var previous_id := -1
+        if not _bee_ids.is_empty():
+                previous_id = _bee_ids[clamp(_selected_index, 0, _bee_ids.size() - 1)]
+        _populate_bee_list()
+        if _bee_ids.is_empty():
+                _status_label.text = "No bees available"
+                _hint_label.text = ""
+                _close_on_any_input = true
+                _timer.wait_time = empty_close_delay
+                _timer.start(empty_close_delay)
+                return
+        _close_on_any_input = false
+        var new_index := _bee_ids.find(previous_id)
+        if new_index == -1:
+                new_index = 0
+        _selected_index = new_index
+        _apply_selection()
+*** End of File

--- a/scripts/ui/BeeRoster.gd
+++ b/scripts/ui/BeeRoster.gd
@@ -117,31 +117,24 @@ func try_assign_to_cell(axial: Vector2i) -> bool:
 		_set_status("Bee data unavailable.")
 		_assignment_armed = false
 		return false
-	var spec: String = bee.get("specialisation", "GATHER")
-	if spec == "GATHER":
-		_set_status("Gatherers await future field jobs; pick another specialisation.")
-		_assignment_armed = false
-		_update_assignment_highlight()
-		return false
-	if _hex_grid:
-		var cell_type: int = _hex_grid.get_cell_type(axial.x, axial.y)
-		var cap: int = _hex_grid.get_bee_cap(axial.x, axial.y)
-		if cap <= 0:
-			_set_status("%s cannot house bees." % CellType.to_display_name(cell_type))
-			_assignment_armed = false
-			_update_assignment_highlight()
-			return false
-		var allowed: Array = _hex_grid.get_cell_types_for_specialisation(spec)
-		if allowed.is_empty() or not allowed.has(cell_type):
-			_set_status("%s bees cannot work in %s." % [_format_spec(spec), CellType.to_display_name(cell_type)])
-			_assignment_armed = false
-			_update_assignment_highlight()
-			return false
-		if _hex_grid.get_bee_count(axial.x, axial.y) >= cap:
-			_set_status("%s at (%d,%d) is already full." % [CellType.to_display_name(cell_type), axial.x, axial.y])
-			_assignment_armed = false
-			_update_assignment_highlight()
-			return false
+        if _hex_grid:
+                var cell_type: int = _hex_grid.get_cell_type(axial.x, axial.y)
+                if not _hex_grid.cell_is_eligible_for_bee(axial.x, axial.y):
+                        _set_status("%s cannot house bees." % CellType.to_display_name(cell_type))
+                        _assignment_armed = false
+                        _update_assignment_highlight()
+                        return false
+                var cap: int = _hex_grid.cell_bee_cap(axial.x, axial.y)
+                if cap <= 0:
+                        _set_status("%s cannot house bees." % CellType.to_display_name(cell_type))
+                        _assignment_armed = false
+                        _update_assignment_highlight()
+                        return false
+                if _hex_grid.cell_bee_count(axial.x, axial.y) >= cap:
+                        _set_status("%s at (%d,%d) is already full." % [CellType.to_display_name(cell_type), axial.x, axial.y])
+                        _assignment_armed = false
+                        _update_assignment_highlight()
+                        return false
 	var success := BeeManager.assign_to_cell(_selected_bee_id, axial.x, axial.y)
 	if success:
 		_set_status("Bee #%d assigned to (%d,%d)." % [_selected_bee_id, axial.x, axial.y])


### PR DESCRIPTION
## Summary
- convert hatched brood cells into the damaged state and emit bee spawns through the bee manager
- add configurable bee capacity helpers on the hex grid and expose a keyboard-driven assignment picker
- update the roster and input handling to support assigning and unassigning bees without specialisations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e240326c8483229d5666d47b1bce2c