### PR TITLE
Fix indentation in brood assignment handler

### DIFF
--- a/scripts/grid/HexGrid.gd
+++ b/scripts/grid/HexGrid.gd
@@ -698,9 +698,9 @@ func _on_egg_assigned(q: int, r: int) -> void:
                 if is_instance_valid(egg_manager):
                         egg_manager.refund_egg()
                 return
-	if data.brood_state != HexCell.BroodState.IDLE:
-		return
-	_begin_brood_incubation(axial, data)
+        if data.brood_state != HexCell.BroodState.IDLE:
+                return
+        _begin_brood_incubation(axial, data)
 
 func _convert_empty_to_brood(axial: Vector2i, data: CellData) -> void:
 	var brood_color := grid_config.get_color(CellType.Type.BROOD)


### PR DESCRIPTION
## Summary
- replace tab-indented lines in `_on_egg_assigned` with spaces to match the file's indentation style
- prevent Godot parser errors caused by inconsistent indentation in the brood assignment handler

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2619899a08322950f99b609beb27b