### PR TITLE
Avoid nested typed arrays in cluster collection

### DIFF
--- a/scripts/grid/HexGrid.gd
+++ b/scripts/grid/HexGrid.gd
@@ -194,8 +194,8 @@ func get_total_sprouts() -> int:
 		total += data.sprout_count
 	return total
 
-func collect_clusters(cell_type: int) -> Array[Array[Vector2i]]:
-	var clusters: Array[Array[Vector2i]] = []
+func collect_clusters(cell_type: int) -> Array:
+        var clusters: Array = []
 	var visited: Dictionary = {}
 	for axial in _cell_states.keys():
 		var data: CellData = _cell_states[axial]


### PR DESCRIPTION
## Summary
- update the HexGrid cluster collection helper to return a general Array instead of a nested typed Array
- adjust the local clusters container to avoid nested typed arrays that Godot does not support

## Testing
- not run (Godot CLI not available)


------
https://chatgpt.com/codex/tasks/task_e_68e350e2a99883229f673db4d48dc6ef