### PR TITLE
Fix HexGrid cluster indentation

### DIFF
--- a/scripts/grid/HexGrid.gd
+++ b/scripts/grid/HexGrid.gd
@@ -195,7 +195,7 @@ func get_total_sprouts() -> int:
 	return total
 
 func collect_clusters(cell_type: int) -> Array:
-        var clusters: Array = []
+	var clusters: Array = []
 	var visited: Dictionary = {}
 	for axial in _cell_states.keys():
 		var data: CellData = _cell_states[axial]


### PR DESCRIPTION
## Summary
- fix the indentation of the cluster initialization line in HexGrid.gd so the script parses correctly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e35200336c8322821f29d07c714029