### PR TITLE
Fix neighbor typing in hex grid

### DIFF
--- a/scripts/core/Coord.gd
+++ b/scripts/core/Coord.gd
@@ -8,10 +8,10 @@ const SQRT3 := sqrt(3.0)
 
 ## Direction vectors for the six neighboring axial coordinates. The order is
 ## clockwise starting at the eastern neighbor.
-const DIRECTIONS := [
-	Vector2i(1, 0),
-	Vector2i(0, 1),
-	Vector2i(-1, 1),
+const DIRECTIONS: Array[Vector2i] = [
+        Vector2i(1, 0),
+        Vector2i(0, 1),
+        Vector2i(-1, 1),
 	Vector2i(-1, 0),
 	Vector2i(0, -1),
 	Vector2i(1, -1),


### PR DESCRIPTION
## Summary
- type the hex direction constants so neighbor calculations keep a concrete type
- annotate grid dictionaries and neighbor iteration variables to avoid Variant inference warnings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e353f5986c8322a90019be5386bd1e