### PR TITLE
Fix HexGrid indentation causing parse error

### DIFF
--- a/scripts/grid/HexGrid.gd
+++ b/scripts/grid/HexGrid.gd
@@ -61,7 +61,7 @@ func _generate_grid() -> void:
 			cell.configure(axial, grid_config.cell_size, grid_config.selection_color, color)
 			cells[axial] = cell
 
-                        var data: CellData = CellData.new()
+			var data: CellData = CellData.new()
 			data.set_type(cell_type, color)
 			if cell_type == CellType.Type.TOTEM:
 				data.variant_id = "totem_default"


### PR DESCRIPTION
## Summary
- replace the stray space-indented line in `HexGrid.gd` with tab indentation so the parser no longer errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e39001e8e88322a0a91e98e3b2ca6f