### PR TITLE
Fix inconsistent indentation in HexGrid.gd

### DIFF
--- a/scripts/grid/HexGrid.gd
+++ b/scripts/grid/HexGrid.gd
@@ -113,12 +113,12 @@ func get_cell_data(axial: Vector2i) -> CellData:
 	return _cell_states.get(axial)
 
 func get_neighbors(axial: Vector2i) -> Array[Vector2i]:
-        var result: Array[Vector2i] = []
-        for direction: Vector2i in Coord.DIRECTIONS:
-                var neighbor: Vector2i = axial + direction
-                if _cell_states.has(neighbor):
-                        result.append(neighbor)
-        return result
+	var result: Array[Vector2i] = []
+	for direction: Vector2i in Coord.DIRECTIONS:
+		var neighbor: Vector2i = axial + direction
+		if _cell_states.has(neighbor):
+			result.append(neighbor)
+	return result
 
 func get_cells_of_type(cell_type: int) -> Array[Vector2i]:
 	var positions: Array[Vector2i] = []
@@ -129,11 +129,11 @@ func get_cells_of_type(cell_type: int) -> Array[Vector2i]:
 	return positions
 
 func count_neighbors_of_type(axial: Vector2i, cell_type: int) -> int:
-        var count := 0
-        for neighbor: Vector2i in get_neighbors(axial):
-                if get_cell_type_at(neighbor) == cell_type:
-                        count += 1
-        return count
+	var count := 0
+	for neighbor: Vector2i in get_neighbors(axial):
+		if get_cell_type_at(neighbor) == cell_type:
+			count += 1
+	return count
 
 func highlight_cell(axial: Vector2i, selected: bool) -> void:
 	var cell: HexCell = cells.get(axial)
@@ -189,33 +189,33 @@ func process_turn() -> Dictionary:
 	}
 
 func get_total_sprouts() -> int:
-        var total := 0
-        for data: CellData in _cell_states.values():
-                total += data.sprout_count
-        return total
+	var total := 0
+	for data: CellData in _cell_states.values():
+		total += data.sprout_count
+	return total
 
 func collect_clusters(cell_type: int) -> Array:
-        var clusters: Array = []
-        var visited: Dictionary[Vector2i, bool] = {}
+	var clusters: Array = []
+	var visited: Dictionary[Vector2i, bool] = {}
 	for axial in _cell_states.keys():
 		var data: CellData = _cell_states[axial]
 		if data.cell_type != cell_type:
 			continue
 		if visited.has(axial):
 			continue
-                var cluster: Array[Vector2i] = []
-                var pending: Array[Vector2i] = [axial]
-                while not pending.is_empty():
-                        var current: Vector2i = pending.pop_back()
-                        if visited.has(current):
-                                continue
-                        visited[current] = true
-                        cluster.append(current)
-                        for neighbor: Vector2i in get_neighbors(current):
-                                if visited.has(neighbor):
-                                        continue
-                                if get_cell_type_at(neighbor) == cell_type:
-                                        pending.append(neighbor)
+		var cluster: Array[Vector2i] = []
+		var pending: Array[Vector2i] = [axial]
+		while not pending.is_empty():
+			var current: Vector2i = pending.pop_back()
+			if visited.has(current):
+				continue
+			visited[current] = true
+			cluster.append(current)
+			for neighbor: Vector2i in get_neighbors(current):
+				if visited.has(neighbor):
+					continue
+				if get_cell_type_at(neighbor) == cell_type:
+					pending.append(neighbor)
 		if not cluster.is_empty():
 			clusters.append(cluster)
 	return clusters
@@ -226,11 +226,11 @@ func _update_cursor_position() -> void:
 	_cursor_node.position = axial_to_world(_cursor_axial)
 
 func _is_connected_to_network(axial: Vector2i) -> bool:
-        for neighbor: Vector2i in get_neighbors(axial):
-                var neighbor_type: int = get_cell_type_at(neighbor)
-                if CellType.is_network_member(neighbor_type):
-                        return true
-        return false
+	for neighbor: Vector2i in get_neighbors(axial):
+		var neighbor_type: int = get_cell_type_at(neighbor)
+		if CellType.is_network_member(neighbor_type):
+			return true
+	return false
 
 func _recompute_overgrowth() -> void:
 	var empty_cells: Array[Vector2i] = []
@@ -246,23 +246,23 @@ func _recompute_overgrowth() -> void:
 	if empty_cells.is_empty():
 		return
 
-        var boundary: Array[Vector2i] = []
-        for axial in empty_cells:
-                if _is_boundary(axial):
-                        boundary.append(axial)
+	var boundary: Array[Vector2i] = []
+	for axial in empty_cells:
+		if _is_boundary(axial):
+			boundary.append(axial)
 
-        var outside: Dictionary[Vector2i, bool] = {}
-        var queue: Array[Vector2i] = boundary.duplicate()
-        while not queue.is_empty():
-                var current: Vector2i = queue.pop_back()
-                if outside.has(current):
-                        continue
-                outside[current] = true
-                for direction: Vector2i in Coord.DIRECTIONS:
-                        var neighbor: Vector2i = current + direction
-                        if not _cell_states.has(neighbor):
-                                continue
-                        var neighbor_data: CellData = _cell_states[neighbor]
+	var outside: Dictionary[Vector2i, bool] = {}
+	var queue: Array[Vector2i] = boundary.duplicate()
+	while not queue.is_empty():
+		var current: Vector2i = queue.pop_back()
+		if outside.has(current):
+			continue
+		outside[current] = true
+		for direction: Vector2i in Coord.DIRECTIONS:
+			var neighbor: Vector2i = current + direction
+			if not _cell_states.has(neighbor):
+				continue
+			var neighbor_data: CellData = _cell_states[neighbor]
 			if neighbor_data.cell_type != CellType.Type.EMPTY:
 				continue
 			if outside.has(neighbor):


### PR DESCRIPTION
## Summary
- replace space-indented blocks in HexGrid.gd with tabs to match the rest of the script
- ensure helper methods such as cluster collection and overgrowth recomputation use consistent indentation so the file parses correctly

## Testing
- not run (Godot CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e39203fa38832298bbf921d1fdb8fa