### PR TITLE
Handle missing UI node references

### DIFF
--- a/scripts/ui/BuildPalette.gd
+++ b/scripts/ui/BuildPalette.gd
@@ -8,8 +8,8 @@ const PaletteState := preload("res://scripts/input/PaletteState.gd")
 @export var palette_state_path: NodePath
 @export var header: String = "Tile Palette"
 
-@onready var _title_label: Label = $Panel/Margin/VBox/Title
-@onready var _items_container: GridContainer = $Panel/Margin/VBox/Items
+@onready var _title_label: Label = get_node_or_null("Panel/Margin/VBox/Title")
+@onready var _items_container: GridContainer = get_node_or_null("Panel/Margin/VBox/Items")
 @onready var _viewport: Viewport = get_viewport()
 
 var _palette_state: PaletteState
@@ -23,7 +23,10 @@ func _ready() -> void:
     if not _palette_state:
         push_warning("BuildPalette requires a PaletteState node")
         return
-    _title_label.text = header
+    if _title_label:
+        _title_label.text = header
+    else:
+        push_warning("BuildPalette missing Title label; skipping header setup")
     visible = false
 
     if _viewport:
@@ -43,6 +46,9 @@ func set_tile_descriptions(descriptions: Dictionary) -> void:
     _refresh_label_tooltips()
 
 func _create_labels() -> void:
+    if not _items_container:
+        push_warning("BuildPalette missing Items container; cannot create labels")
+        return
     for child in _items_container.get_children():
         child.queue_free()
     _labels.clear()
@@ -62,6 +68,8 @@ func _create_labels() -> void:
 func _refresh_counts() -> void:
     for cell_type in _labels.keys():
         var label: Label = _labels[cell_type]
+        if not label:
+            continue
         var base_name := CellType.to_display_name(cell_type)
         var count := _palette_state.get_count(cell_type)
         if count > 0:
@@ -72,6 +80,8 @@ func _refresh_counts() -> void:
 func _refresh_label_tooltips() -> void:
     for cell_type in _labels.keys():
         var label: Label = _labels[cell_type]
+        if not label:
+            continue
         label.tooltip_text = String(_descriptions.get(cell_type, ""))
 
 func _on_palette_opened() -> void:
@@ -95,6 +105,8 @@ func _on_options_changed() -> void:
 func _refresh_selection_visuals(selected_type: int) -> void:
     for cell_type in _labels.keys():
         var label: Label = _labels[cell_type]
+        if not label:
+            continue
         if cell_type == selected_type:
             label.add_theme_color_override("font_color", Color.WHITE)
             label.self_modulate = Color(1, 1, 1, 1)
@@ -106,6 +118,8 @@ func _refresh_selection_visuals(selected_type: int) -> void:
 func _refresh_in_hand_visuals(in_hand_type) -> void:
     for cell_type in _labels.keys():
         var label: Label = _labels[cell_type]
+        if not label:
+            continue
         var base_name := label.text
         if in_hand_type != null and cell_type == in_hand_type:
             if not base_name.ends_with(" *"):

--- a/scripts/ui/RunInfoPanel.gd
+++ b/scripts/ui/RunInfoPanel.gd
@@ -4,34 +4,42 @@ class_name RunInfoPanel
 
 const CellType := preload("res://scripts/core/CellType.gd")
 
-@onready var _turn_label: Label = $Panel/Margin/VBox/TurnLabel
-@onready var _deck_label: Label = $Panel/Margin/VBox/DeckLabel
-@onready var _sprout_label: Label = $Panel/Margin/VBox/SproutLabel
-@onready var _nature_label: Label = $Panel/Margin/VBox/ResourceGrid/NatureValue
-@onready var _earth_label: Label = $Panel/Margin/VBox/ResourceGrid/EarthValue
-@onready var _water_label: Label = $Panel/Margin/VBox/ResourceGrid/WaterValue
-@onready var _life_label: Label = $Panel/Margin/VBox/ResourceGrid/LifeValue
+@onready var _turn_label: Label = get_node_or_null("Panel/Margin/VBox/TurnLabel")
+@onready var _deck_label: Label = get_node_or_null("Panel/Margin/VBox/DeckLabel")
+@onready var _sprout_label: Label = get_node_or_null("Panel/Margin/VBox/SproutLabel")
+@onready var _nature_label: Label = get_node_or_null("Panel/Margin/VBox/ResourceGrid/NatureValue")
+@onready var _earth_label: Label = get_node_or_null("Panel/Margin/VBox/ResourceGrid/EarthValue")
+@onready var _water_label: Label = get_node_or_null("Panel/Margin/VBox/ResourceGrid/WaterValue")
+@onready var _life_label: Label = get_node_or_null("Panel/Margin/VBox/ResourceGrid/LifeValue")
 
 func update_turn(turn: int) -> void:
-    _turn_label.text = "Turn: %d" % max(turn, 0)
+    if _turn_label:
+        _turn_label.text = "Turn: %d" % max(turn, 0)
 
 func update_deck(total_remaining: int, counts: Dictionary) -> void:
-    _deck_label.text = "Deck: %d tiles remaining" % max(total_remaining, 0)
+    if _deck_label:
+        _deck_label.text = "Deck: %d tiles remaining" % max(total_remaining, 0)
     var breakdown: Array[String] = []
     for cell_type in CellType.buildable_types():
         var count := int(counts.get(cell_type, 0))
         if count > 0:
             breakdown.append("%s x%d" % [CellType.to_display_name(cell_type), count])
-    _deck_label.tooltip_text = ", ".join(breakdown)
+    if _deck_label:
+        _deck_label.tooltip_text = ", ".join(breakdown)
 
 func update_resources(resources: Dictionary, generation: Dictionary) -> void:
-    _nature_label.text = _format_resource("nature", resources, generation)
-    _earth_label.text = _format_resource("earth", resources, generation)
-    _water_label.text = _format_resource("water", resources, generation)
-    _life_label.text = _format_resource("life", resources, generation)
+    if _nature_label:
+        _nature_label.text = _format_resource("nature", resources, generation)
+    if _earth_label:
+        _earth_label.text = _format_resource("earth", resources, generation)
+    if _water_label:
+        _water_label.text = _format_resource("water", resources, generation)
+    if _life_label:
+        _life_label.text = _format_resource("life", resources, generation)
 
 func update_sprouts(total: int) -> void:
-    _sprout_label.text = "Sprouts: %d" % max(total, 0)
+    if _sprout_label:
+        _sprout_label.text = "Sprouts: %d" % max(total, 0)
 
 func _format_resource(key: String, resources: Dictionary, generation: Dictionary) -> String:
     var entry: Dictionary = resources.get(key, {})


### PR DESCRIPTION
## Summary
- guard BuildPalette against missing UI children and log warnings instead of crashing
- make RunInfoPanel use get_node_or_null and skip updates when labels are absent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e39ba042548322ab4d3fdc1964f715