### PR TITLE
Implement core hex helpers and placement rules

### DIFF
--- a/scenes/Cursor.tscn
+++ b/scenes/Cursor.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://cursor_display"]
+
+[ext_resource type="Script" path="res://src/ui/Cursor.gd" id="1_d5qrs"]
+
+[node name="Cursor" type="Node2D"]
+script = ExtResource("1_d5qrs")

--- a/scenes/Grid.tscn
+++ b/scenes/Grid.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://debug_grid"]
+
+[ext_resource type="Script" path="res://src/systems/Grid.gd" id="1_54y7y"]
+
+[node name="Grid" type="Node2D"]
+script = ExtResource("1_54y7y")

--- a/src/core/Hex.gd
+++ b/src/core/Hex.gd
@@ -1,0 +1,90 @@
+extends RefCounted
+## Utility helpers for working with axial hexagonal coordinates in a flat-topped grid.
+class_name Hex
+
+const SQRT3 := sqrt(3.0)
+
+class Axial:
+        var q: int
+        var r: int
+
+        func _init(q: int = 0, r: int = 0) -> void:
+                self.q = q
+                self.r = r
+
+        func to_vector2i() -> Vector2i:
+                return Vector2i(q, r)
+
+        static func from_vector2i(value: Vector2i) -> Axial:
+                return Axial.new(value.x, value.y)
+
+        func offset(delta: Axial) -> Axial:
+                return Axial.new(q + delta.q, r + delta.r)
+
+const DIRECTIONS: Array[Axial] = [
+        Axial.new(1, 0),
+        Axial.new(0, 1),
+        Axial.new(-1, 1),
+        Axial.new(-1, 0),
+        Axial.new(0, -1),
+        Axial.new(1, -1),
+]
+
+static func neighbors(axial: Axial) -> Array[Axial]:
+        var result: Array[Axial] = []
+        for direction in DIRECTIONS:
+                result.append(axial.offset(direction))
+        return result
+
+static func axial_to_world(axial: Axial, cell_size: float) -> Vector2:
+        var q := float(axial.q)
+        var r := float(axial.r)
+        var x := cell_size * (1.5 * q)
+        var y := cell_size * (SQRT3 * (r + q / 2.0))
+        return Vector2(x, y)
+
+static func world_to_axial(position: Vector2, cell_size: float) -> Axial:
+        var q := ((2.0 / 3.0) * position.x) / cell_size
+        var r := ((-1.0 / 3.0) * position.x + (SQRT3 / 3.0) * position.y) / cell_size
+        return Axial.from_vector2i(_cube_round(Vector3(q, -q - r, r)))
+
+static func ring(center: Axial, radius: int) -> Array[Axial]:
+        var results: Array[Axial] = []
+        if radius < 0:
+                return results
+        if radius == 0:
+                results.append(center)
+                return results
+        var axial := center.offset(_scale(DIRECTIONS[4], radius))
+        for direction in DIRECTIONS:
+                for _i in range(radius):
+                        results.append(axial)
+                        axial = axial.offset(direction)
+        return results
+
+static func distance(a: Axial, b: Axial) -> int:
+        var dq := a.q - b.q
+        var dr := a.r - b.r
+        var ds := (-a.q - a.r) - (-b.q - b.r)
+        return int((abs(dq) + abs(dr) + abs(ds)) / 2)
+
+static func _cube_round(cube: Vector3) -> Vector2i:
+        var rx := round(cube.x)
+        var ry := round(cube.y)
+        var rz := round(cube.z)
+
+        var x_diff := abs(rx - cube.x)
+        var y_diff := abs(ry - cube.y)
+        var z_diff := abs(rz - cube.z)
+
+        if x_diff > y_diff and x_diff > z_diff:
+                rx = -ry - rz
+        elif y_diff > z_diff:
+                ry = -rx - rz
+        else:
+                rz = -rx - ry
+
+        return Vector2i(int(rx), int(rz))
+
+static func _scale(axial: Axial, factor: int) -> Axial:
+        return Axial.new(axial.q * factor, axial.r * factor)

--- a/src/core/InputMap.gd
+++ b/src/core/InputMap.gd
@@ -1,0 +1,61 @@
+extends Node
+## Configures the project's input actions at runtime so both keyboard and gamepad
+## bindings are centralized in one place.
+class_name InputMapConfig
+
+const ACTION_DEFINITIONS := {
+        "ui_left": [
+                _key_event(KEY_LEFT),
+                _joypad_button_event(JOY_BUTTON_DPAD_LEFT),
+        ],
+        "ui_right": [
+                _key_event(KEY_RIGHT),
+                _joypad_button_event(JOY_BUTTON_DPAD_RIGHT),
+        ],
+        "ui_up": [
+                _key_event(KEY_UP),
+                _joypad_button_event(JOY_BUTTON_DPAD_UP),
+        ],
+        "ui_down": [
+                _key_event(KEY_DOWN),
+                _joypad_button_event(JOY_BUTTON_DPAD_DOWN),
+        ],
+        "confirm": [
+                _key_event(KEY_SPACE),
+                _joypad_button_event(JOY_BUTTON_A),
+        ],
+        "cancel": [
+                _key_event(KEY_Z),
+                _joypad_button_event(JOY_BUTTON_B),
+        ],
+        "panel_next": [
+                _key_event(KEY_TAB),
+                _joypad_button_event(JOY_BUTTON_START),
+        ],
+}
+
+static func apply() -> void:
+        ## Ensures the engine's InputMap matches the default bindings declared above.
+        for action_name in ACTION_DEFINITIONS.keys():
+                _register_action(action_name, ACTION_DEFINITIONS[action_name])
+
+static func _register_action(action_name: String, events: Array) -> void:
+        if not InputMap.has_action(action_name):
+                InputMap.add_action(action_name)
+        else:
+                InputMap.action_erase_events(action_name)
+        for event in events:
+                if event:
+                        InputMap.action_add_event(action_name, event)
+
+static func _key_event(keycode: Key) -> InputEventKey:
+        var event := InputEventKey.new()
+        event.keycode = keycode
+        event.physical_keycode = keycode
+        return event
+
+static func _joypad_button_event(button: int) -> InputEventJoypadButton:
+        var event := InputEventJoypadButton.new()
+        event.button_index = button
+        return event
+

--- a/src/systems/Grid.gd
+++ b/src/systems/Grid.gd
@@ -1,0 +1,72 @@
+extends Node2D
+## Draws a debug hex grid and manages a cursor that moves in axial space.
+class_name HexGridDebug
+
+const Hex := preload("res://src/core/Hex.gd")
+const InputMapConfig := preload("res://src/core/InputMap.gd")
+const CursorScene := preload("res://scenes/Cursor.tscn")
+
+@export var radius: int = 7
+@export var cell_size: float = 32.0
+@export var grid_color: Color = Color(0.4, 0.4, 0.4, 0.8)
+
+var _cursor_axial := Hex.Axial.new()
+var _cursor_node: HexCursorDisplay
+
+func _ready() -> void:
+        InputMapConfig.apply()
+        _spawn_cursor()
+        queue_redraw()
+
+func _unhandled_input(event: InputEvent) -> void:
+        if event.is_action_pressed("ui_left"):
+                _try_move_cursor(Vector2i(-1, 0))
+        elif event.is_action_pressed("ui_right"):
+                _try_move_cursor(Vector2i(1, 0))
+        elif event.is_action_pressed("ui_up"):
+                _try_move_cursor(Vector2i(0, -1))
+        elif event.is_action_pressed("ui_down"):
+                _try_move_cursor(Vector2i(0, 1))
+
+func _draw() -> void:
+        for axial in _enumerate_hexes():
+                var center := Hex.axial_to_world(axial, cell_size)
+                var points := _hex_outline(center)
+                if points.size() > 1:
+                        draw_polyline(points, grid_color, 1.0)
+
+func _spawn_cursor() -> void:
+        if _cursor_node:
+                remove_child(_cursor_node)
+                _cursor_node.queue_free()
+        _cursor_node = CursorScene.instantiate()
+        add_child(_cursor_node)
+        _cursor_node.set_cell_size(cell_size)
+        _cursor_node.position = Hex.axial_to_world(_cursor_axial, cell_size)
+
+func _try_move_cursor(delta: Vector2i) -> void:
+        var target := Hex.Axial.new(_cursor_axial.q + delta.x, _cursor_axial.r + delta.y)
+        if Hex.distance(target, Hex.Axial.new()) > radius:
+                return
+        _cursor_axial = target
+        if _cursor_node:
+                _cursor_node.position = Hex.axial_to_world(_cursor_axial, cell_size)
+
+func _enumerate_hexes() -> Array[Hex.Axial]:
+        var results: Array[Hex.Axial] = []
+        for q in range(-radius, radius + 1):
+                for r in range(-radius, radius + 1):
+                        if abs(q + r) > radius:
+                                continue
+                        results.append(Hex.Axial.new(q, r))
+        return results
+
+func _hex_outline(center: Vector2) -> PackedVector2Array:
+        var outline := PackedVector2Array()
+        var radius_world := cell_size
+        for index in range(6):
+                var angle := deg_to_rad(60.0 * index + 30.0)
+                var point := center + Vector2(cos(angle), sin(angle)) * radius_world
+                outline.append(point)
+        outline.append(outline[0])
+        return outline

--- a/src/systems/PlacementRules.gd
+++ b/src/systems/PlacementRules.gd
@@ -1,0 +1,59 @@
+extends RefCounted
+## Enforces connected placement rules for tiles on the hex grid.
+class_name PlacementRules
+
+const Hex := preload("res://src/core/Hex.gd")
+
+var connected_set: Dictionary[Vector2i, bool] = {}
+
+func _init(initial_connected: Array = []) -> void:
+        set_connected(initial_connected)
+
+func set_connected(axials: Array) -> void:
+        connected_set.clear()
+        for axial in axials:
+                _add_to_connected(axial)
+
+func mark_connected(axial) -> void:
+        _add_to_connected(axial)
+
+func can_place(at, occupied) -> bool:
+        var target := _to_vector(at)
+        if _contains(occupied, target):
+                return false
+        for neighbor in Hex.neighbors(Hex.Axial.from_vector2i(target)):
+                var neighbor_vec := neighbor.to_vector2i()
+                if connected_set.has(neighbor_vec):
+                        return true
+        return false
+
+func _add_to_connected(value) -> void:
+        var vec := _to_vector(value)
+        connected_set[vec] = true
+
+static func _to_vector(value) -> Vector2i:
+        if value is Hex.Axial:
+                return value.to_vector2i()
+        if value is Vector2i:
+                return value
+        if value is Vector2:
+                return Vector2i(int(value.x), int(value.y))
+        push_warning("Unsupported axial value: %s" % [value])
+        return Vector2i.ZERO
+
+static func _contains(collection, value: Vector2i) -> bool:
+        if collection == null:
+                return false
+        match typeof(collection):
+                TYPE_DICTIONARY:
+                        return collection.has(value)
+                TYPE_ARRAY:
+                        return collection.has(value)
+                TYPE_OBJECT:
+                        if collection.has_method("has"):
+                                return collection.has(value)
+                        return false
+                TYPE_PACKED_VECTOR2_ARRAY:
+                        return PackedVector2Array(collection).has(value)
+                _:
+                        return false

--- a/src/ui/Cursor.gd
+++ b/src/ui/Cursor.gd
@@ -1,0 +1,31 @@
+extends Node2D
+## Simple visual representation of the grid cursor.
+class_name HexCursorDisplay
+
+@export var color: Color = Color(1, 1, 0, 1)
+@export var line_width: float = 2.0
+
+var cell_size: float = 32.0 : set = set_cell_size
+
+func _ready() -> void:
+        queue_redraw()
+
+func set_cell_size(value: float) -> void:
+        cell_size = value
+        queue_redraw()
+
+func _draw() -> void:
+        var points := _hex_points()
+        if points.is_empty():
+                return
+        var outline := PackedVector2Array(points)
+        outline.append(points[0])
+        draw_polyline(outline, color, line_width)
+
+func _hex_points() -> Array[Vector2]:
+        var points: Array[Vector2] = []
+        var radius := cell_size
+        for index in range(6):
+                var angle := deg_to_rad(60.0 * index + 30.0)
+                points.append(Vector2(cos(angle), sin(angle)) * radius)
+        return points

--- a/tests/grid_test.gd
+++ b/tests/grid_test.gd
@@ -1,13 +1,60 @@
 extends RefCounted
 
-const Coord := preload("res://scripts/core/Coord.gd")
+const Hex := preload("res://src/core/Hex.gd")
 
-func test_axial_conversion_round_trip() -> void:
-	var size := 32.0
-	for q in range(-2, 3):
-		for r in range(-2, 3):
-			if abs(q + r) > 2:
-				continue
-			var position := Coord.axial_to_world(Vector2i(q, r), size)
-			var round_trip: Vector2i = Coord.world_to_axial(position, size)
-			assert(round_trip == Vector2i(q, r))
+func test_axial_neighbors() -> bool:
+        var origin := Hex.Axial.new(0, 0)
+        var neighbors := Hex.neighbors(origin)
+        var expected := [
+                Hex.Axial.new(1, 0),
+                Hex.Axial.new(0, 1),
+                Hex.Axial.new(-1, 1),
+                Hex.Axial.new(-1, 0),
+                Hex.Axial.new(0, -1),
+                Hex.Axial.new(1, -1),
+        ]
+        var remaining := expected.duplicate()
+        for neighbor in neighbors:
+                var idx := _index_of_axial(remaining, neighbor)
+                if idx == -1:
+                        push_error("Unexpected neighbor: %s" % [neighbor.to_vector2i()])
+                        return false
+                remaining.remove_at(idx)
+        if not remaining.is_empty():
+                var missing: Array[Vector2i] = []
+                for axial in remaining:
+                        missing.append(axial.to_vector2i())
+                push_error("Missing neighbors: %s" % [missing])
+                return false
+        return true
+
+func test_axial_conversion_round_trip() -> bool:
+        var size := 32.0
+        for q in range(-2, 3):
+                for r in range(-2, 3):
+                        if abs(q + r) > 2:
+                                continue
+                        var axial := Hex.Axial.new(q, r)
+                        var position := Hex.axial_to_world(axial, size)
+                        var round_trip: Hex.Axial = Hex.world_to_axial(position, size)
+                        if round_trip.q != axial.q or round_trip.r != axial.r:
+                                push_error("Round trip mismatch for %s -> %s" % [axial.to_vector2i(), round_trip.to_vector2i()])
+                                return false
+        return true
+
+func test_ring_count_matches_radius() -> bool:
+        var center := Hex.Axial.new(0, 0)
+        for radius in range(0, 4):
+                var ring := Hex.ring(center, radius)
+                var expected_count := 1 if radius == 0 else radius * 6
+                if ring.size() != expected_count:
+                        push_error("Ring radius %d expected %d but got %d" % [radius, expected_count, ring.size()])
+                        return false
+        return true
+
+static func _index_of_axial(haystack: Array, needle: Hex.Axial) -> int:
+        for index in range(haystack.size()):
+                var value: Hex.Axial = haystack[index]
+                if value.q == needle.q and value.r == needle.r:
+                        return index
+        return -1

--- a/tests/placement_rules_test.gd
+++ b/tests/placement_rules_test.gd
@@ -1,0 +1,35 @@
+extends RefCounted
+
+const Hex := preload("res://src/core/Hex.gd")
+const PlacementRules := preload("res://src/systems/PlacementRules.gd")
+
+func test_cannot_place_on_occupied_cell() -> bool:
+        var rules := PlacementRules.new([Hex.Axial.new(0, 0)])
+        var occupied := {Vector2i(1, 0): true}
+        if rules.can_place(Vector2i(1, 0), occupied):
+                push_error("Should not place on occupied cell")
+                return false
+        return true
+
+func test_requires_neighbor_in_connected_set() -> bool:
+        var rules := PlacementRules.new([Hex.Axial.new(0, 0)])
+        var empty := {}
+        if not rules.can_place(Vector2i(1, 0), empty):
+                push_error("Expected placement adjacent to connected set to succeed")
+                return false
+        if rules.can_place(Vector2i(2, 0), empty):
+                push_error("Placement without adjacency should fail")
+                return false
+        return true
+
+func test_mark_connected_expands_network() -> bool:
+        var rules := PlacementRules.new([Hex.Axial.new(0, 0)])
+        var empty := {}
+        if not rules.can_place(Vector2i(1, 0), empty):
+                push_error("First neighbor should be buildable")
+                return false
+        rules.mark_connected(Vector2i(1, 0))
+        if not rules.can_place(Vector2i(2, 0), empty):
+                push_error("Newly connected tile should allow further placements")
+                return false
+        return true

--- a/tests/run_tests.gd
+++ b/tests/run_tests.gd
@@ -1,0 +1,19 @@
+extends SceneTree
+
+const TEST_SCRIPTS := [
+        preload("res://tests/grid_test.gd"),
+        preload("res://tests/placement_rules_test.gd"),
+]
+
+func _init() -> void:
+        var failed := false
+        for script in TEST_SCRIPTS:
+                var test_case := script.new()
+                for method in test_case.get_method_list():
+                        var name: String = method.name
+                        if not name.begins_with("test_"):
+                                continue
+                        var result = test_case.call(name)
+                        if result is bool and not result:
+                                failed = true
+        quit(failed ? 1 : 0)


### PR DESCRIPTION
## Summary
- centralize input bindings for grid navigation and UI actions
- add axial hex math helpers, placement rule logic, and reusable cursor/grid scenes
- cover the new helpers with lightweight GDScript tests and a simple headless runner

## Testing
- not run (Godot binary not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e39ec7da288322aae46e20bc89dc9e