### PR TITLE
Implement config loader, draft flow, and deck construction

### DIFF
--- a/data/decay.json
+++ b/data/decay.json
@@ -1,0 +1,1 @@
+{ "totems":{"count":2,"spread_every_turns":3,"attacks_per_turn":3} }

--- a/data/deck.json
+++ b/data/deck.json
@@ -1,12 +1,1 @@
-{
-  "default_distribution": {
-    "Harvest": 8,
-    "Build": 6,
-    "Refine": 4,
-    "Guard": 4,
-    "Storage": 3,
-    "Upgrade": 3,
-    "Chanting": 1
-  },
-  "notes": "Default 30-tile deck distribution for the Sprouts prototype."
-}
+{ "distribution": { "Harvest":8, "Build":6, "Refine":4, "Guard":4, "Storage":3, "Upgrade":3, "Chanting":1 } }

--- a/data/sprouts.json
+++ b/data/sprouts.json
@@ -1,0 +1,1 @@
+{ "base_hp":3, "trait_weights":{"brave":1,"nimble":1} }

--- a/data/tiles.json
+++ b/data/tiles.json
@@ -1,66 +1,77 @@
 {
-  "Harvest": {
-    "id": "harvest_default",
-    "name": "Harvest Tile",
-    "summary": "Generates Nature Essence per adjacent Grove; expands Nature capacity.",
-    "details": [
-      "Nature Essence: +1 per adjacent Grove each turn.",
-      "Nature Capacity: +5 per Harvest tile.",
-      "Harvest clusters grant +10 Nature capacity per tile."
-    ]
-  },
-  "Build": {
-    "id": "build_default",
-    "name": "Build Tile",
-    "summary": "Produces Earth Essence and provides structure for adjacent systems.",
-    "details": [
-      "Earth Essence: +1 each turn.",
-      "Earth Capacity: +5 per Build tile.",
-      "Supports Refine and Guard tiles that are adjacent."
-    ]
-  },
-  "Refine": {
-    "id": "refine_default",
-    "name": "Refine Tile",
-    "summary": "Condenses Nature and Earth Essence into Water Essence when linked.",
-    "details": [
-      "Water Essence: +1 each turn if adjacent to Nature and Earth producers.",
-      "Water Capacity: +5 per Refine tile.",
-      "Refine clusters double Water Essence output."
-    ]
-  },
-  "Storage": {
-    "id": "storage_default",
-    "name": "Storage Tile",
-    "summary": "Expands capacity for nearby producers.",
-    "details": [
-      "Adds +5 capacity to each adjacent Harvest, Build, or Refine tile.",
-      "Storage tiles do not generate Essence on their own."
-    ]
-  },
-  "Guard": {
-    "id": "guard_default",
-    "name": "Guard Tile",
-    "summary": "Hosts Sprouts who defend nearby hexes.",
-    "details": [
-      "Base Sprout capacity: 5 Sprouts per Guard tile.",
-      "Battles trigger within a 3-hex radius (not yet implemented)."
-    ]
-  },
-  "Upgrade": {
-    "id": "upgrade_default",
-    "name": "Upgrade Tile",
-    "summary": "Forges items for Sprouts over time.",
-    "details": [
-      "Creates combat items on a timer (systems stubbed in the prototype)."
-    ]
-  },
-  "Chanting": {
-    "id": "chanting_default",
-    "name": "Chanting Tile",
-    "summary": "Builds rituals that unleash powerful one-time spells.",
-    "details": [
-      "Generates ritual progress toward a spell (effects stubbed in the prototype)."
+  "categories": ["Harvest","Build","Refine","Storage","Guard","Upgrade","Chanting","Grove"],
+  "variants": {
+    "Harvest": [
+      {
+        "id": "harvest_default",
+        "name": "Harvest — Default",
+        "effects": {
+          "nature_per_adjacent_grove": 1,
+          "cluster_global_cap_bonus": 10
+        }
+      }
+    ],
+    "Build": [
+      {
+        "id": "build_default",
+        "effects": {
+          "earth_per_turn": 1
+        }
+      }
+    ],
+    "Refine": [
+      {
+        "id": "refine_default",
+        "effects": {
+          "cooldown_turns": 2,
+          "convert": {
+            "nature": 1,
+            "earth": 1,
+            "water": 1
+          }
+        }
+      }
+    ],
+    "Storage": [
+      {
+        "id": "storage_default",
+        "effects": {
+          "adjacent_capacity_bonus": 5
+        }
+      }
+    ],
+    "Guard": [
+      {
+        "id": "guard_default",
+        "effects": {
+          "sprout_slots": 5,
+          "battle_range": 3
+        }
+      }
+    ],
+    "Upgrade": [
+      {
+        "id": "upgrade_default",
+        "effects": {
+          "item_timer": 3
+        }
+      }
+    ],
+    "Chanting": [
+      {
+        "id": "chant_default",
+        "effects": {
+          "ritual_pool": ["cleanse_adjacent"]
+        }
+      }
+    ],
+    "Grove": [
+      {
+        "id": "grove_base",
+        "effects": {
+          "spawns_sprout": true
+        }
+      }
     ]
   }
 }

--- a/data/totems.json
+++ b/data/totems.json
@@ -1,0 +1,1 @@
+{ "totems":[{"id":"heartwood","tiers":[{"tier":1,"life_cost":0,"aura":{}},{"tier":2,"life_cost":10,"aura":{"nature_adjacent_grove":1}}]}] }

--- a/project.godot
+++ b/project.godot
@@ -14,6 +14,11 @@ config/name="Sprouts"
 run/main_scene="res://scenes/Main.tscn"
 config/features=PackedStringArray("4.4")
 
+[autoload]
+
+Config="*res://src/data/Config.gd"
+RunState="*res://src/core/RunState.gd"
+
 [input]
 
 ui_accept={
@@ -60,6 +65,14 @@ ui_down={
 "type": "key"
 }, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194322,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
+}
+ui_cancel={
+"deadzone": 0.5,
+"events": [{
+"keycode": 90,
+"physical_keycode": 90,
+"type": "key"
+}, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":90,"key_label":0,"unicode":122,"location":0,"echo":false,"script":null)]
 }
 
 [rendering]

--- a/scenes/Draft.tscn
+++ b/scenes/Draft.tscn
@@ -1,0 +1,41 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://src/ui/Draft.gd" id="1"]
+
+[node name="Draft" type="Control"]
+script = ExtResource("1")
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -640.0
+offset_top = -360.0
+offset_right = 640.0
+offset_bottom = 360.0
+
+[node name="Root" type="VBoxContainer" parent="."]
+layout_mode = 2
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 40.0
+offset_top = 40.0
+offset_right = -40.0
+offset_bottom = -40.0
+alignment = BoxContainer.ALIGNMENT_CENTER
+
+[node name="CategoryLabel" type="Label" parent="Root"]
+layout_mode = 2
+text = ""
+horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+
+[node name="CardContainer" type="HBoxContainer" parent="Root"]
+layout_mode = 2
+size_flags_vertical = Control.SIZE_EXPAND_FILL
+alignment = BoxContainer.ALIGNMENT_CENTER
+separation = 24
+
+[node name="InstructionsLabel" type="Label" parent="Root"]
+layout_mode = 2
+text = "Use ←/→ to choose, Space to confirm, Z to go back"
+horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER

--- a/scripts/core/RunState.gd
+++ b/scripts/core/RunState.gd
@@ -1,6 +1,5 @@
 extends Node
 ## Coordinates deck management, turn resolution, and resource tracking for a run.
-class_name RunState
 
 const CellType := preload("res://scripts/core/CellType.gd")
 const HexGrid := preload("res://scripts/grid/HexGrid.gd")

--- a/src/core/RunState.gd
+++ b/src/core/RunState.gd
@@ -1,0 +1,23 @@
+extends Node
+class_name RunState
+
+const Deck := preload("res://src/systems/Deck.gd")
+
+var seed:int = 0
+var chosen_variants:Dictionary = {}
+var deck:Array = []
+var draw_index:int = 0
+
+func start_new_run() -> void:
+    seed = int(Time.get_unix_time_from_system())
+    Config.load_all()
+    chosen_variants = {}
+    deck = []
+    draw_index = 0
+
+func finalize_after_draft() -> void:
+    var distribution : Dictionary = {}
+    if Config.deck().has("distribution"):
+        distribution = Config.deck()["distribution"]
+    deck = Deck.build_deck(chosen_variants, distribution, seed)
+    draw_index = 0

--- a/src/core/TileTypes.gd
+++ b/src/core/TileTypes.gd
@@ -1,0 +1,31 @@
+extends RefCounted
+class_name TileTypes
+
+enum TileCategory { Harvest, Build, Refine, Storage, Guard, Upgrade, Chanting, Grove }
+
+static var _map := {
+    "Harvest": TileCategory.Harvest,
+    "Build": TileCategory.Build,
+    "Refine": TileCategory.Refine,
+    "Storage": TileCategory.Storage,
+    "Guard": TileCategory.Guard,
+    "Upgrade": TileCategory.Upgrade,
+    "Chanting": TileCategory.Chanting,
+    "Grove": TileCategory.Grove
+}
+
+static func category_from_string(s:String) -> int:
+    return _map.get(s, -1)
+
+static func string_from_category(cat:int) -> String:
+    for k in _map.keys():
+        if _map[k] == cat:
+            return k
+    return ""
+
+static func variant_exists(category:int, id:String) -> bool:
+    var s := string_from_category(category)
+    if s == "":
+        return false
+    var variant := Config.get_variant(s, id)
+    return variant is Dictionary and not variant.is_empty()

--- a/src/data/Config.gd
+++ b/src/data/Config.gd
@@ -1,0 +1,132 @@
+extends Node
+class_name Config
+
+var _tiles := {}
+var _deck := {}
+var _totems := {}
+var _sprouts := {}
+var _decay := {}
+
+func load_all() -> void:
+    _tiles = _load_json("res://data/tiles.json")
+    _deck = _load_json("res://data/deck.json")
+    _totems = _load_json("res://data/totems.json")
+    _sprouts = _load_json("res://data/sprouts.json")
+    _decay = _load_json("res://data/decay.json")
+    if not _validate_tiles(_tiles):
+        _tiles = {}
+    if not _validate_deck(_deck):
+        _deck = {}
+
+func tiles() -> Dictionary:
+    return _tiles
+
+func deck() -> Dictionary:
+    return _deck
+
+func totems() -> Dictionary:
+    return _totems
+
+func sprouts() -> Dictionary:
+    return _sprouts
+
+func decay() -> Dictionary:
+    return _decay
+
+func get_variant(category:String, id:String) -> Dictionary:
+    if not _tiles.has("variants"):
+        return {}
+    var variants := _tiles["variants"]
+    if typeof(variants) != TYPE_DICTIONARY:
+        return {}
+    if not variants.has(category):
+        return {}
+    for v in variants[category]:
+        if typeof(v) == TYPE_DICTIONARY and v.get("id", "") == id:
+            return v
+    return {}
+
+func _load_json(path:String) -> Dictionary:
+    if not FileAccess.file_exists(path):
+        push_error("Missing JSON: %s" % path)
+        return {}
+    var f := FileAccess.open(path, FileAccess.READ)
+    if f == null:
+        push_error("Unable to open JSON: %s" % path)
+        return {}
+    var text := f.get_as_text()
+    var data = JSON.parse_string(text)
+    if typeof(data) != TYPE_DICTIONARY:
+        push_error("Invalid JSON: %s" % path)
+        return {}
+    return data
+
+func _validate_tiles(t:Dictionary) -> bool:
+    if t.is_empty():
+        _fatal_config("tiles.json missing or empty")
+        return false
+    if not t.has("categories") or not t.has("variants"):
+        _fatal_config("tiles.json missing keys")
+        return false
+    var categories = t["categories"]
+    if typeof(categories) != TYPE_ARRAY:
+        _fatal_config("tiles.json categories must be an array")
+        return false
+    for c in categories:
+        if typeof(c) != TYPE_STRING:
+            _fatal_config("tiles.json categories must be strings")
+            return false
+    var variants = t["variants"]
+    if typeof(variants) != TYPE_DICTIONARY:
+        _fatal_config("tiles.json variants must be a dictionary")
+        return false
+    for category in categories:
+        if not variants.has(category):
+            _fatal_config("tiles.json missing variants for %s" % category)
+            return false
+        var entries = variants[category]
+        if typeof(entries) != TYPE_ARRAY:
+            _fatal_config("tiles.json variants for %s must be an array" % category)
+            return false
+        for entry in entries:
+            if typeof(entry) != TYPE_DICTIONARY:
+                _fatal_config("tiles.json variant entries must be dictionaries")
+                return false
+            var vid = entry.get("id", "")
+            if typeof(vid) != TYPE_STRING or vid.is_empty():
+                _fatal_config("tiles.json variant id missing for %s" % category)
+                return false
+            if not entry.has("effects") or typeof(entry["effects"]) != TYPE_DICTIONARY:
+                _fatal_config("tiles.json variant %s missing effects" % vid)
+                return false
+    return true
+
+func _validate_deck(d:Dictionary) -> bool:
+    if d.is_empty():
+        _fatal_config("deck.json missing or empty")
+        return false
+    if not d.has("distribution"):
+        _fatal_config("deck.json missing distribution")
+        return false
+    var distribution = d["distribution"]
+    if typeof(distribution) != TYPE_DICTIONARY:
+        _fatal_config("deck.json distribution must be a dictionary")
+        return false
+    for k in distribution.keys():
+        if typeof(distribution[k]) != TYPE_INT:
+            _fatal_config("deck.json distribution values must be int")
+            return false
+    return true
+
+func _fatal_config(msg:String) -> void:
+    push_error(msg)
+    var tree := get_tree()
+    if tree == null:
+        return
+    var error_scene := "res://scenes/ui/ErrorPanel.tscn"
+    if ResourceLoader.exists(error_scene):
+        tree.change_scene_to_file(error_scene)
+        return
+    var main_scene := ProjectSettings.get_setting("application/run/main_scene", "")
+    if typeof(main_scene) == TYPE_STRING and main_scene != "":
+        tree.change_scene_to_file(main_scene)

--- a/src/systems/Deck.gd
+++ b/src/systems/Deck.gd
@@ -1,0 +1,32 @@
+extends Node
+class_name Deck
+
+static func build_deck(chosen:Dictionary, distribution:Dictionary, seed:int) -> Array:
+    var entries : Array = []
+    var tile_data := Config.tiles()
+    var tile_variants := tile_data.get("variants", {})
+    for cat in distribution.keys():
+        var count : int = int(distribution[cat])
+        var vid := str(chosen.get(cat, ""))
+        if vid.is_empty():
+            if typeof(tile_variants) == TYPE_DICTIONARY:
+                var pool := tile_variants.get(cat, [])
+                if typeof(pool) == TYPE_ARRAY and pool.size() > 0:
+                    vid = str(pool[0].get("id", ""))
+            if vid.is_empty():
+                push_warning("Missing chosen variant for %s" % cat)
+                continue
+            push_warning("Missing chosen variant for %s, fallback=%s" % [cat, vid])
+        for i in range(max(count, 0)):
+            entries.append({ "category": cat, "variant_id": vid })
+    shuffle_in_place(entries, seed)
+    return entries
+
+static func shuffle_in_place(arr:Array, seed:int) -> void:
+    var rng := RandomNumberGenerator.new()
+    rng.seed = seed
+    for i in range(arr.size() - 1, 0, -1):
+        var j := rng.randi_range(0, i)
+        var tmp = arr[i]
+        arr[i] = arr[j]
+        arr[j] = tmp

--- a/src/ui/Draft.gd
+++ b/src/ui/Draft.gd
@@ -1,0 +1,149 @@
+extends Control
+
+signal draft_completed
+
+var _categories := ["Harvest","Build","Refine","Storage","Guard","Upgrade","Chanting"]
+var _index := 0
+var _choices : Array = []
+var _picked : Dictionary = {}
+var _rng := RandomNumberGenerator.new()
+var _selection := 0
+
+@onready var _category_label: Label = %CategoryLabel
+@onready var _card_container: HBoxContainer = %CardContainer
+@onready var _instructions_label: Label = %InstructionsLabel
+
+func _ready():
+    _rng.seed = Time.get_unix_time_from_system()
+    _index = 0
+    _picked.clear()
+    _next_category()
+
+func _next_category():
+    if _index >= _categories.size():
+        RunState.chosen_variants = _picked.duplicate(true)
+        emit_signal("draft_completed")
+        return
+    _show_category(_index)
+
+func _show_category(idx:int) -> void:
+    var cat := _categories[idx]
+    _choices = _sample_three(cat)
+    _render_cards(cat, _choices)
+
+func _sample_three(cat:String) -> Array:
+    var variants := []
+    if Config.tiles().has("variants"):
+        var pool = Config.tiles()["variants"].get(cat, [])
+        if typeof(pool) == TYPE_ARRAY:
+            variants = pool.duplicate(true)
+    var available := variants.size()
+    if available <= 0:
+        return []
+    var count := min(3, available)
+    var results : Array = []
+    for i in range(count):
+        var idx := _rng.randi_range(0, variants.size() - 1)
+        results.append(variants[idx])
+        variants.remove_at(idx)
+    return results
+
+func _render_cards(cat:String, choices:Array) -> void:
+    _selection = 0
+    if _category_label:
+        _category_label.text = "Select a %s tile" % cat
+    if _instructions_label:
+        _instructions_label.text = "Use ←/→ to choose, Space to confirm, Z to go back"
+    if _card_container:
+        while _card_container.get_child_count() > 0:
+            var child := _card_container.get_child(0)
+            _card_container.remove_child(child)
+            child.queue_free()
+        for choice in choices:
+            var card := _create_card(choice)
+            _card_container.add_child(card)
+    _update_highlight()
+
+func _create_card(choice:Dictionary) -> Control:
+    var card := VBoxContainer.new()
+    card.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+    card.alignment = BoxContainer.ALIGNMENT_CENTER
+    card.custom_minimum_size = Vector2(180, 0)
+    var name_label := Label.new()
+    name_label.text = str(choice.get("name", choice.get("id", "Unknown")))
+    name_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+    var id_label := Label.new()
+    id_label.text = str(choice.get("id", ""))
+    id_label.modulate = Color(0.7, 0.7, 0.9)
+    id_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+    var effects_label := Label.new()
+    effects_label.text = _summarize_effects(choice.get("effects", {}))
+    effects_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+    effects_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+    card.add_child(name_label)
+    card.add_child(id_label)
+    card.add_child(effects_label)
+    return card
+
+func _summarize_effects(effects:Variant) -> String:
+    if typeof(effects) != TYPE_DICTIONARY:
+        return ""
+    var parts : Array = []
+    for key in effects.keys():
+        var value = effects[key]
+        if typeof(value) in [TYPE_DICTIONARY, TYPE_ARRAY]:
+            parts.append("%s: %s" % [key, JSON.stringify(value)])
+        else:
+            parts.append("%s: %s" % [key, str(value)])
+    return ", ".join(parts)
+
+func _unhandled_input(event: InputEvent) -> void:
+    if event.is_action_pressed("ui_left"):
+        _move_sel(-1)
+    elif event.is_action_pressed("ui_right"):
+        _move_sel(1)
+    elif event.is_action_pressed("ui_accept"):
+        _confirm_pick()
+    elif event.is_action_pressed("ui_cancel"):
+        _go_back()
+
+func _move_sel(delta:int) -> void:
+    if _choices.is_empty():
+        return
+    var size := _choices.size()
+    _selection = (_selection + delta) % size
+    if _selection < 0:
+        _selection += size
+    _update_highlight()
+
+func _update_highlight() -> void:
+    if not _card_container:
+        return
+    var idx := 0
+    for child in _card_container.get_children():
+        if child is Control:
+            child.modulate = Color(1, 1, 1, 1) if idx == _selection else Color(0.7, 0.7, 0.7, 1)
+        idx += 1
+
+func _current_sel() -> int:
+    return _selection
+
+func _confirm_pick():
+    if _choices.is_empty():
+        return
+    var cat := _categories[_index]
+    var sel := clamp(_current_sel(), 0, _choices.size() - 1)
+    var picked_id := str(_choices[sel].get("id", ""))
+    if picked_id != "":
+        _picked[cat] = picked_id
+        _index += 1
+        _next_category()
+
+func _go_back():
+    if _index <= 0:
+        return
+    _index -= 1
+    var cat := _categories[_index]
+    if _picked.has(cat):
+        _picked.erase(cat)
+    _show_category(_index)

--- a/src/ui/PanelSwitcher.gd
+++ b/src/ui/PanelSwitcher.gd
@@ -1,0 +1,47 @@
+extends Node
+class_name PanelSwitcher
+
+var _panels : Dictionary = {}
+var _order : Array = []
+var _current := ""
+
+func _ready() -> void:
+    ensure_draft_panel()
+
+func register_panel(name:String, node:Node) -> void:
+    if node == null:
+        return
+    _panels[name] = node
+    if not _order.has(name):
+        _order.append(name)
+    if _current == "":
+        _current = name
+
+func ensure_draft_panel() -> void:
+    if _panels.has("Draft"):
+        return
+    if has_node("Draft"):
+        register_panel("Draft", get_node("Draft"))
+
+func show(name:String) -> void:
+    if not _panels.has(name):
+        return
+    for key in _panels.keys():
+        var panel = _panels[key]
+        if panel is CanvasItem:
+            panel.visible = key == name
+    _current = name
+
+func cycle(direction:int = 1) -> void:
+    if _order.is_empty():
+        return
+    ensure_draft_panel()
+    var idx := _order.find(_current)
+    if idx == -1:
+        idx = 0
+    else:
+        idx = (idx + direction) % _order.size()
+        if idx < 0:
+            idx += _order.size()
+    var name := _order[idx]
+    show(name)

--- a/tests/run_tests.gd
+++ b/tests/run_tests.gd
@@ -3,6 +3,10 @@ extends SceneTree
 const TEST_SCRIPTS := [
         preload("res://tests/grid_test.gd"),
         preload("res://tests/placement_rules_test.gd"),
+        preload("res://tests/test_config_load.gd"),
+        preload("res://tests/test_tiletypes.gd"),
+        preload("res://tests/test_draft_logic.gd"),
+        preload("res://tests/test_deck_build.gd"),
 ]
 
 func _init() -> void:

--- a/tests/test_config_load.gd
+++ b/tests/test_config_load.gd
@@ -1,0 +1,17 @@
+extends RefCounted
+
+func test_config_load_all() -> bool:
+    Config.load_all()
+    var tiles := Config.tiles()
+    if tiles.is_empty():
+        return false
+    if not tiles.has("categories") or not tiles.has("variants"):
+        return false
+    var deck_data := Config.deck()
+    if not deck_data.has("distribution"):
+        return false
+    var variant := Config.get_variant("Harvest", "harvest_default")
+    if variant.is_empty():
+        return false
+    var effects := variant.get("effects", {})
+    return effects.has("nature_per_adjacent_grove")

--- a/tests/test_deck_build.gd
+++ b/tests/test_deck_build.gd
@@ -1,0 +1,58 @@
+extends RefCounted
+
+func _basic_chosen() -> Dictionary:
+    var chosen : Dictionary = {}
+    var variants := Config.tiles().get("variants", {})
+    if typeof(variants) != TYPE_DICTIONARY:
+        return chosen
+    for cat in Config.tiles().get("categories", []):
+        var pool := variants.get(cat, [])
+        if typeof(pool) == TYPE_ARRAY and pool.size() > 0:
+            chosen[cat] = pool[0].get("id", "")
+    return chosen
+
+func _distribution_total(dist:Dictionary) -> int:
+    var total := 0
+    for key in dist.keys():
+        total += int(dist[key])
+    return total
+
+func test_build_deck_uses_distribution() -> bool:
+    Config.load_all()
+    var chosen := _basic_chosen()
+    var distribution := Config.deck().get("distribution", {})
+    var deck := Deck.build_deck(chosen, distribution, 123)
+    if deck.size() != _distribution_total(distribution):
+        return false
+    for entry in deck:
+        if not entry.has("category") or not entry.has("variant_id"):
+            return false
+        var cat := entry["category"]
+        if chosen.has(cat) and entry["variant_id"] != chosen[cat]:
+            return false
+    return true
+
+func test_shuffle_is_deterministic() -> bool:
+    Config.load_all()
+    var chosen := _basic_chosen()
+    var distribution := Config.deck().get("distribution", {})
+    var deck1 := Deck.build_deck(chosen, distribution, 999)
+    var deck2 := Deck.build_deck(chosen, distribution, 999)
+    var deck3 := Deck.build_deck(chosen, distribution, 1000)
+    if deck1 != deck2:
+        return false
+    return deck1 == deck2 and deck1 != deck3
+
+func test_missing_chosen_variant_falls_back() -> bool:
+    Config.load_all()
+    var chosen := _basic_chosen()
+    chosen.erase("Storage")
+    var distribution := Config.deck().get("distribution", {})
+    var total := _distribution_total(distribution)
+    var deck := Deck.build_deck(chosen, distribution, 42)
+    if deck.size() != total:
+        return false
+    for entry in deck:
+        if entry["category"] == "Storage":
+            return entry["variant_id"] != ""
+    return true

--- a/tests/test_draft_logic.gd
+++ b/tests/test_draft_logic.gd
@@ -1,0 +1,49 @@
+extends RefCounted
+
+const DraftScene := preload("res://scenes/Draft.tscn")
+
+func _instantiate_draft() -> Control:
+    var tree := Engine.get_main_loop()
+    if not (tree is SceneTree):
+        return null
+    var draft := DraftScene.instantiate()
+    tree.root.add_child(draft)
+    return draft
+
+func _cleanup_draft(draft:Control) -> void:
+    if draft == null:
+        return
+    if draft.get_parent():
+        draft.get_parent().remove_child(draft)
+    draft.queue_free()
+
+func test_draft_selects_all_categories() -> bool:
+    Config.load_all()
+    RunState.start_new_run()
+    var draft := _instantiate_draft()
+    if draft == null:
+        return false
+    var completed := false
+    draft.draft_completed.connect(func(): completed = true)
+    for i in range(7):
+        draft._confirm_pick()
+    var expected := ["Harvest","Build","Refine","Storage","Guard","Upgrade","Chanting"]
+    var chosen := RunState.chosen_variants
+    var success := completed and chosen.size() == expected.size()
+    for cat in expected:
+        success = success and chosen.has(cat)
+    _cleanup_draft(draft)
+    return success
+
+func test_go_back_resets_previous_choice() -> bool:
+    Config.load_all()
+    RunState.start_new_run()
+    var draft := _instantiate_draft()
+    if draft == null:
+        return false
+    draft._confirm_pick()
+    var progressed := draft._index == 1
+    draft._go_back()
+    var reset := draft._index == 0 and not draft._picked.has("Harvest")
+    _cleanup_draft(draft)
+    return progressed and reset

--- a/tests/test_tiletypes.gd
+++ b/tests/test_tiletypes.gd
@@ -1,0 +1,20 @@
+extends RefCounted
+
+func test_roundtrip_categories() -> bool:
+    Config.load_all()
+    var names := ["Harvest","Build","Refine","Storage","Guard","Upgrade","Chanting","Grove"]
+    for name in names:
+        var cat := TileTypes.category_from_string(name)
+        if cat == -1:
+            return false
+        if TileTypes.string_from_category(cat) != name:
+            return false
+    return true
+
+func test_invalid_category_returns_minus_one() -> bool:
+    return TileTypes.category_from_string("Unknown") == -1
+
+func test_variant_exists_helper() -> bool:
+    Config.load_all()
+    var cat := TileTypes.category_from_string("Harvest")
+    return TileTypes.variant_exists(cat, "harvest_default")


### PR DESCRIPTION
## Summary
- add a Config autoload that loads and validates JSON for tiles, decks, totems, sprouts, and decay
- introduce tile category helpers, draft UI flow, and deck construction utilities backed by RunState
- seed JSON data and expand the automated test suite to cover config loading, tile types, draft flow, and deck building

## Testing
- not run (godot binary is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e3a87658ec83229973e43932d3b0b8