### PR TITLE
Fix singleton conflicts and add type annotations

### DIFF
--- a/scripts/input/InputController.gd
+++ b/scripts/input/InputController.gd
@@ -67,9 +67,9 @@ func _unhandled_input(event: InputEvent) -> void:
 			return
 		if event.is_action_pressed("ui_accept"):
 			var selected_type: int = _palette_state.confirm_selection()
-			if selected_type != CellType.Type.EMPTY and _has_pending_build and _run_state:
-				var placed := _run_state.try_place_tile(_pending_build_axial, selected_type)
-				if placed:
+                        if selected_type != CellType.Type.EMPTY and _has_pending_build and _run_state:
+                                var placed: bool = _run_state.try_place_tile(_pending_build_axial, selected_type)
+                                if placed:
 					_has_pending_build = false
 					if _palette_state and _palette_state.has_in_hand():
 						_palette_state.clear_in_hand()

--- a/src/core/RunState.gd
+++ b/src/core/RunState.gd
@@ -1,5 +1,4 @@
 extends Node
-class_name RunState
 
 const Deck := preload("res://src/systems/Deck.gd")
 


### PR DESCRIPTION
## Summary
- remove `class_name` declarations from autoloaded Config and RunState scripts to avoid singleton conflicts
- add explicit Variant and concrete type handling throughout Config data parsing helpers
- annotate the build placement check in InputController so the compiler can infer the boolean result

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3ac38cef88322a06e7d1783f68ac5