### PR TITLE
Annotate deck builder variables to avoid Variant inference warning

### DIFF
--- a/src/systems/Deck.gd
+++ b/src/systems/Deck.gd
@@ -3,14 +3,14 @@ class_name Deck
 
 static func build_deck(chosen:Dictionary, distribution:Dictionary, seed:int) -> Array:
     var entries : Array = []
-    var tile_data := Config.tiles()
-    var tile_variants := tile_data.get("variants", {})
+    var tile_data: Dictionary = Config.tiles()
+    var tile_variants: Variant = tile_data.get("variants", {})
     for cat in distribution.keys():
         var count : int = int(distribution[cat])
         var vid := str(chosen.get(cat, ""))
         if vid.is_empty():
             if typeof(tile_variants) == TYPE_DICTIONARY:
-                var maybe_pool = tile_variants.get(cat, [])
+                var maybe_pool: Variant = tile_variants.get(cat, [])
                 if typeof(maybe_pool) == TYPE_ARRAY:
                     var pool_array := maybe_pool as Array
                     if pool_array.size() > 0:
@@ -30,6 +30,6 @@ static func shuffle_in_place(arr:Array, seed:int) -> void:
     rng.seed = seed
     for i in range(arr.size() - 1, 0, -1):
         var j := rng.randi_range(0, i)
-        var tmp = arr[i]
+        var tmp: Variant = arr[i]
         arr[i] = arr[j]
         arr[j] = tmp


### PR DESCRIPTION
## Summary
- add explicit type annotations for deck-building data pulled from dictionaries to prevent Variant inference warnings
- ensure temporary shuffle variable is declared with a type to satisfy strict typing

## Testing
- not run (Godot not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3af53912c83228735f4669f3e9c57