### PR TITLE
Avoid RunState autoload type conflict

### DIFF
--- a/scripts/input/InputController.gd
+++ b/scripts/input/InputController.gd
@@ -8,11 +8,11 @@ extends Node
 const CellType := preload("res://scripts/core/CellType.gd")
 const HexGrid := preload("res://scripts/grid/HexGrid.gd")
 const PaletteState := preload("res://scripts/input/PaletteState.gd")
-const RunState := preload("res://scripts/core/RunState.gd")
+const RunStateController := preload("res://scripts/core/RunState.gd")
 
 var _hex_grid: HexGrid
 var _palette_state: PaletteState
-var _run_state: RunState
+var _run_state: RunStateController
 var _pending_build_axial: Vector2i = Vector2i.ZERO
 var _has_pending_build: bool = false
 


### PR DESCRIPTION
## Summary
- rename the InputController's local RunState preload to RunStateController to avoid shadowing the autoloaded RunState
- update the typed member to use the renamed preload so the controller can assign the scene RunState without type errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3b067570c83228032232edbb0eab4