### PR TITLE
Fix test type warnings and deck loading errors

### DIFF
--- a/tests/test_config_load.gd
+++ b/tests/test_config_load.gd
@@ -2,16 +2,22 @@ extends RefCounted
 
 func test_config_load_all() -> bool:
     Config.load_all()
-    var tiles := Config.tiles()
+    var tiles: Dictionary = Config.tiles()
     if tiles.is_empty():
         return false
     if not tiles.has("categories") or not tiles.has("variants"):
         return false
-    var deck_data := Config.deck()
+    var deck_variant: Variant = Config.deck()
+    if typeof(deck_variant) != TYPE_DICTIONARY:
+        return false
+    var deck_data: Dictionary = deck_variant
     if not deck_data.has("distribution"):
         return false
-    var variant := Config.get_variant("Harvest", "harvest_default")
+    var variant: Dictionary = Config.get_variant("Harvest", "harvest_default")
     if variant.is_empty():
         return false
-    var effects := variant.get("effects", {})
+    var effects_variant: Variant = variant.get("effects", {})
+    if typeof(effects_variant) != TYPE_DICTIONARY:
+        return false
+    var effects: Dictionary = effects_variant
     return effects.has("nature_per_adjacent_grove")

--- a/tests/test_deck_build.gd
+++ b/tests/test_deck_build.gd
@@ -1,61 +1,102 @@
 extends RefCounted
 
 func _basic_chosen() -> Dictionary:
-    var chosen : Dictionary = {}
-    var variants := Config.tiles().get("variants", {})
-    if typeof(variants) != TYPE_DICTIONARY:
+    var chosen: Dictionary = {}
+    var tiles: Dictionary = Config.tiles()
+    var variants_variant: Variant = tiles.get("variants", {})
+    if typeof(variants_variant) != TYPE_DICTIONARY:
         return chosen
-    for cat in Config.tiles().get("categories", []):
-        var maybe_pool = variants.get(cat, [])
-        if typeof(maybe_pool) == TYPE_ARRAY:
-            var pool_array := maybe_pool as Array
-            if pool_array.size() > 0:
-                var first_variant := pool_array[0] as Dictionary
-                chosen[cat] = first_variant.get("id", "")
+    var variants: Dictionary = variants_variant
+    var categories_variant: Variant = tiles.get("categories", [])
+    if typeof(categories_variant) != TYPE_ARRAY:
+        return chosen
+    var categories: Array = categories_variant
+    for category_variant in categories:
+        if typeof(category_variant) != TYPE_STRING:
+            continue
+        var cat: String = category_variant
+        var maybe_pool: Variant = variants.get(cat, [])
+        if typeof(maybe_pool) != TYPE_ARRAY:
+            continue
+        var pool_array: Array = maybe_pool
+        if pool_array.is_empty():
+            continue
+        var first_variant_variant: Variant = pool_array[0]
+        if typeof(first_variant_variant) != TYPE_DICTIONARY:
+            continue
+        var first_variant: Dictionary = first_variant_variant
+        var variant_id_variant: Variant = first_variant.get("id", "")
+        if typeof(variant_id_variant) == TYPE_STRING:
+            var variant_id: String = variant_id_variant
+            chosen[cat] = variant_id
     return chosen
 
 func _distribution_total(dist:Dictionary) -> int:
     var total := 0
     for key in dist.keys():
-        total += int(dist[key])
+        var count_variant: Variant = dist.get(key, 0)
+        total += int(count_variant)
     return total
 
 func test_build_deck_uses_distribution() -> bool:
     Config.load_all()
-    var chosen := _basic_chosen()
-    var distribution := Config.deck().get("distribution", {})
-    var deck := Deck.build_deck(chosen, distribution, 123)
+    var chosen: Dictionary = _basic_chosen()
+    var distribution_variant: Variant = Config.deck().get("distribution", {})
+    if typeof(distribution_variant) != TYPE_DICTIONARY:
+        return false
+    var distribution: Dictionary = distribution_variant
+    var deck: Array = Deck.build_deck(chosen, distribution, 123)
     if deck.size() != _distribution_total(distribution):
         return false
-    for entry in deck:
+    for entry_variant in deck:
+        if typeof(entry_variant) != TYPE_DICTIONARY:
+            return false
+        var entry: Dictionary = entry_variant
         if not entry.has("category") or not entry.has("variant_id"):
             return false
-        var cat := entry["category"]
-        if chosen.has(cat) and entry["variant_id"] != chosen[cat]:
+        var category_variant: Variant = entry.get("category", "")
+        if typeof(category_variant) != TYPE_STRING:
+            return false
+        var cat: String = category_variant
+        var variant_id: String = str(entry.get("variant_id", ""))
+        if chosen.has(cat) and variant_id != str(chosen[cat]):
             return false
     return true
 
 func test_shuffle_is_deterministic() -> bool:
     Config.load_all()
-    var chosen := _basic_chosen()
-    var distribution := Config.deck().get("distribution", {})
-    var deck1 := Deck.build_deck(chosen, distribution, 999)
-    var deck2 := Deck.build_deck(chosen, distribution, 999)
-    var deck3 := Deck.build_deck(chosen, distribution, 1000)
+    var chosen: Dictionary = _basic_chosen()
+    var distribution_variant: Variant = Config.deck().get("distribution", {})
+    if typeof(distribution_variant) != TYPE_DICTIONARY:
+        return false
+    var distribution: Dictionary = distribution_variant
+    var deck1: Array = Deck.build_deck(chosen, distribution, 999)
+    var deck2: Array = Deck.build_deck(chosen, distribution, 999)
+    var deck3: Array = Deck.build_deck(chosen, distribution, 1000)
     if deck1 != deck2:
         return false
     return deck1 == deck2 and deck1 != deck3
 
 func test_missing_chosen_variant_falls_back() -> bool:
     Config.load_all()
-    var chosen := _basic_chosen()
+    var chosen: Dictionary = _basic_chosen()
     chosen.erase("Storage")
-    var distribution := Config.deck().get("distribution", {})
+    var distribution_variant: Variant = Config.deck().get("distribution", {})
+    if typeof(distribution_variant) != TYPE_DICTIONARY:
+        return false
+    var distribution: Dictionary = distribution_variant
     var total := _distribution_total(distribution)
-    var deck := Deck.build_deck(chosen, distribution, 42)
+    var deck: Array = Deck.build_deck(chosen, distribution, 42)
     if deck.size() != total:
         return false
-    for entry in deck:
-        if entry["category"] == "Storage":
-            return entry["variant_id"] != ""
+    for entry_variant in deck:
+        if typeof(entry_variant) != TYPE_DICTIONARY:
+            continue
+        var entry: Dictionary = entry_variant
+        var category_variant: Variant = entry.get("category", "")
+        if typeof(category_variant) != TYPE_STRING:
+            continue
+        var cat: String = category_variant
+        if cat == "Storage":
+            return str(entry.get("variant_id", "")) != ""
     return true

--- a/tests/test_draft_logic.gd
+++ b/tests/test_draft_logic.gd
@@ -1,13 +1,17 @@
 extends RefCounted
 
-const DraftScene := preload("res://scenes/Draft.tscn")
+const DraftScene: PackedScene = preload("res://scenes/Draft.tscn")
 
 func _instantiate_draft() -> Control:
-    var tree := Engine.get_main_loop()
+    var tree: MainLoop = Engine.get_main_loop()
     if not (tree is SceneTree):
         return null
-    var draft := DraftScene.instantiate()
-    tree.root.add_child(draft)
+    var scene_tree: SceneTree = tree
+    var draft_instance: Node = DraftScene.instantiate()
+    if not (draft_instance is Control):
+        return null
+    var draft: Control = draft_instance
+    scene_tree.root.add_child(draft)
     return draft
 
 func _cleanup_draft(draft:Control) -> void:
@@ -27,10 +31,11 @@ func test_draft_selects_all_categories() -> bool:
     draft.draft_completed.connect(func(): completed = true)
     for i in range(7):
         draft._confirm_pick()
-    var expected := ["Harvest","Build","Refine","Storage","Guard","Upgrade","Chanting"]
-    var chosen := RunState.chosen_variants
+    var expected: Array = ["Harvest","Build","Refine","Storage","Guard","Upgrade","Chanting"]
+    var chosen: Dictionary = RunState.chosen_variants
     var success := completed and chosen.size() == expected.size()
-    for cat in expected:
+    for category_variant in expected:
+        var cat: String = str(category_variant)
         success = success and chosen.has(cat)
     _cleanup_draft(draft)
     return success
@@ -42,8 +47,8 @@ func test_go_back_resets_previous_choice() -> bool:
     if draft == null:
         return false
     draft._confirm_pick()
-    var progressed := draft._index == 1
+    var progressed: bool = draft._index == 1
     draft._go_back()
-    var reset := draft._index == 0 and not draft._picked.has("Harvest")
+    var reset: bool = draft._index == 0 and not draft._picked.has("Harvest")
     _cleanup_draft(draft)
     return progressed and reset


### PR DESCRIPTION
## Summary
- add explicit typing and validation to deck-building tests to avoid Variant inference warnings
- ensure draft logic test instantiates the scene safely when running headless
- tighten config load test by validating dictionary types before use

## Testing
- not run (Godot CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3b1f878d0832289c287d3452acb77