### PR TITLE
Fix Godot constant initialization for runtime configuration

### DIFF
--- a/src/core/Hex.gd
+++ b/src/core/Hex.gd
@@ -5,86 +5,89 @@ class_name Hex
 const SQRT3 := sqrt(3.0)
 
 class Axial:
-        var q: int
-        var r: int
+    var q: int
+    var r: int
 
-        func _init(q: int = 0, r: int = 0) -> void:
-                self.q = q
-                self.r = r
+    func _init(q: int = 0, r: int = 0) -> void:
+        self.q = q
+        self.r = r
 
-        func to_vector2i() -> Vector2i:
-                return Vector2i(q, r)
+    func to_vector2i() -> Vector2i:
+        return Vector2i(q, r)
 
-        static func from_vector2i(value: Vector2i) -> Axial:
-                return Axial.new(value.x, value.y)
+    static func from_vector2i(value: Vector2i) -> Axial:
+        return Axial.new(value.x, value.y)
 
-        func offset(delta: Axial) -> Axial:
-                return Axial.new(q + delta.q, r + delta.r)
+    func offset(delta: Axial) -> Axial:
+        return Axial.new(q + delta.q, r + delta.r)
 
-const DIRECTIONS: Array[Axial] = [
-        Axial.new(1, 0),
-        Axial.new(0, 1),
-        Axial.new(-1, 1),
-        Axial.new(-1, 0),
-        Axial.new(0, -1),
-        Axial.new(1, -1),
-]
+static var DIRECTIONS: Array[Axial] = _create_directions()
+
+static func _create_directions() -> Array[Axial]:
+    var directions: Array[Axial] = []
+    directions.append(Axial.new(1, 0))
+    directions.append(Axial.new(0, 1))
+    directions.append(Axial.new(-1, 1))
+    directions.append(Axial.new(-1, 0))
+    directions.append(Axial.new(0, -1))
+    directions.append(Axial.new(1, -1))
+    return directions
 
 static func neighbors(axial: Axial) -> Array[Axial]:
-        var result: Array[Axial] = []
-        for direction in DIRECTIONS:
-                result.append(axial.offset(direction))
-        return result
+    var result: Array[Axial] = []
+    for direction in DIRECTIONS:
+        result.append(axial.offset(direction))
+    return result
 
 static func axial_to_world(axial: Axial, cell_size: float) -> Vector2:
-        var q := float(axial.q)
-        var r := float(axial.r)
-        var x := cell_size * (1.5 * q)
-        var y := cell_size * (SQRT3 * (r + q / 2.0))
-        return Vector2(x, y)
+    var q: float = float(axial.q)
+    var r: float = float(axial.r)
+    var x: float = cell_size * (1.5 * q)
+    var y: float = cell_size * (SQRT3 * (r + q / 2.0))
+    return Vector2(x, y)
 
 static func world_to_axial(position: Vector2, cell_size: float) -> Axial:
-        var q := ((2.0 / 3.0) * position.x) / cell_size
-        var r := ((-1.0 / 3.0) * position.x + (SQRT3 / 3.0) * position.y) / cell_size
-        return Axial.from_vector2i(_cube_round(Vector3(q, -q - r, r)))
+    var q: float = ((2.0 / 3.0) * position.x) / cell_size
+    var r: float = ((-1.0 / 3.0) * position.x + (SQRT3 / 3.0) * position.y) / cell_size
+    return Axial.from_vector2i(_cube_round(Vector3(q, -q - r, r)))
 
 static func ring(center: Axial, radius: int) -> Array[Axial]:
-        var results: Array[Axial] = []
-        if radius < 0:
-                return results
-        if radius == 0:
-                results.append(center)
-                return results
-        var axial := center.offset(_scale(DIRECTIONS[4], radius))
-        for direction in DIRECTIONS:
-                for _i in range(radius):
-                        results.append(axial)
-                        axial = axial.offset(direction)
+    var results: Array[Axial] = []
+    if radius < 0:
         return results
+    if radius == 0:
+        results.append(center)
+        return results
+    var axial: Axial = center.offset(_scale(DIRECTIONS[4], radius))
+    for direction in DIRECTIONS:
+        for _i in range(radius):
+            results.append(axial)
+            axial = axial.offset(direction)
+    return results
 
 static func distance(a: Axial, b: Axial) -> int:
-        var dq := a.q - b.q
-        var dr := a.r - b.r
-        var ds := (-a.q - a.r) - (-b.q - b.r)
-        return int((abs(dq) + abs(dr) + abs(ds)) / 2)
+    var dq := a.q - b.q
+    var dr := a.r - b.r
+    var ds := (-a.q - a.r) - (-b.q - b.r)
+    return int((abs(dq) + abs(dr) + abs(ds)) / 2)
 
 static func _cube_round(cube: Vector3) -> Vector2i:
-        var rx := round(cube.x)
-        var ry := round(cube.y)
-        var rz := round(cube.z)
+    var rx := round(cube.x)
+    var ry := round(cube.y)
+    var rz := round(cube.z)
 
-        var x_diff := abs(rx - cube.x)
-        var y_diff := abs(ry - cube.y)
-        var z_diff := abs(rz - cube.z)
+    var x_diff := abs(rx - cube.x)
+    var y_diff := abs(ry - cube.y)
+    var z_diff := abs(rz - cube.z)
 
-        if x_diff > y_diff and x_diff > z_diff:
-                rx = -ry - rz
-        elif y_diff > z_diff:
-                ry = -rx - rz
-        else:
-                rz = -rx - ry
+    if x_diff > y_diff and x_diff > z_diff:
+        rx = -ry - rz
+    elif y_diff > z_diff:
+        ry = -rx - rz
+    else:
+        rz = -rx - ry
 
-        return Vector2i(int(rx), int(rz))
+    return Vector2i(int(rx), int(rz))
 
 static func _scale(axial: Axial, factor: int) -> Axial:
-        return Axial.new(axial.q * factor, axial.r * factor)
+    return Axial.new(axial.q * factor, axial.r * factor)

--- a/src/core/InputMap.gd
+++ b/src/core/InputMap.gd
@@ -3,59 +3,61 @@ extends Node
 ## bindings are centralized in one place.
 class_name InputMapConfig
 
-const ACTION_DEFINITIONS := {
+static var ACTION_DEFINITIONS: Dictionary = _create_action_definitions()
+
+static func _create_action_definitions() -> Dictionary:
+    return {
         "ui_left": [
-                _key_event(KEY_LEFT),
-                _joypad_button_event(JOY_BUTTON_DPAD_LEFT),
+            _key_event(KEY_LEFT),
+            _joypad_button_event(JOY_BUTTON_DPAD_LEFT),
         ],
         "ui_right": [
-                _key_event(KEY_RIGHT),
-                _joypad_button_event(JOY_BUTTON_DPAD_RIGHT),
+            _key_event(KEY_RIGHT),
+            _joypad_button_event(JOY_BUTTON_DPAD_RIGHT),
         ],
         "ui_up": [
-                _key_event(KEY_UP),
-                _joypad_button_event(JOY_BUTTON_DPAD_UP),
+            _key_event(KEY_UP),
+            _joypad_button_event(JOY_BUTTON_DPAD_UP),
         ],
         "ui_down": [
-                _key_event(KEY_DOWN),
-                _joypad_button_event(JOY_BUTTON_DPAD_DOWN),
+            _key_event(KEY_DOWN),
+            _joypad_button_event(JOY_BUTTON_DPAD_DOWN),
         ],
         "confirm": [
-                _key_event(KEY_SPACE),
-                _joypad_button_event(JOY_BUTTON_A),
+            _key_event(KEY_SPACE),
+            _joypad_button_event(JOY_BUTTON_A),
         ],
         "cancel": [
-                _key_event(KEY_Z),
-                _joypad_button_event(JOY_BUTTON_B),
+            _key_event(KEY_Z),
+            _joypad_button_event(JOY_BUTTON_B),
         ],
         "panel_next": [
-                _key_event(KEY_TAB),
-                _joypad_button_event(JOY_BUTTON_START),
+            _key_event(KEY_TAB),
+            _joypad_button_event(JOY_BUTTON_START),
         ],
-}
+    }
 
 static func apply() -> void:
-        ## Ensures the engine's InputMap matches the default bindings declared above.
-        for action_name in ACTION_DEFINITIONS.keys():
-                _register_action(action_name, ACTION_DEFINITIONS[action_name])
+    ## Ensures the engine's InputMap matches the default bindings declared above.
+    for action_name in ACTION_DEFINITIONS.keys():
+        _register_action(action_name, ACTION_DEFINITIONS[action_name])
 
 static func _register_action(action_name: String, events: Array) -> void:
-        if not InputMap.has_action(action_name):
-                InputMap.add_action(action_name)
-        else:
-                InputMap.action_erase_events(action_name)
-        for event in events:
-                if event:
-                        InputMap.action_add_event(action_name, event)
+    if not InputMap.has_action(action_name):
+        InputMap.add_action(action_name)
+    else:
+        InputMap.action_erase_events(action_name)
+    for event in events:
+        if event:
+            InputMap.action_add_event(action_name, event)
 
 static func _key_event(keycode: Key) -> InputEventKey:
-        var event := InputEventKey.new()
-        event.keycode = keycode
-        event.physical_keycode = keycode
-        return event
+    var event := InputEventKey.new()
+    event.keycode = keycode
+    event.physical_keycode = keycode
+    return event
 
 static func _joypad_button_event(button: int) -> InputEventJoypadButton:
-        var event := InputEventJoypadButton.new()
-        event.button_index = button
-        return event
-
+    var event := InputEventJoypadButton.new()
+    event.button_index = button
+    return event


### PR DESCRIPTION
## Summary
- rebuild the hex direction list at runtime to avoid constant-expression parsing errors
- generate input action definitions through helper functions instead of const dictionaries to satisfy Godot 4 requirements
- add explicit float typing to prevent Variant inference warnings during compilation

## Testing
- `godot --headless --check-only` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e4511119088322a1a7cad6cadb36d5