### PR TITLE
Ensure new runs build a default deck

### DIFF
--- a/src/core/RunState.gd
+++ b/src/core/RunState.gd
@@ -8,11 +8,12 @@ var deck:Array = []
 var draw_index:int = 0
 
 func start_new_run() -> void:
-	seed = int(Time.get_unix_time_from_system())
-	Config.load_all()
-	chosen_variants = {}
-	deck = []
-	draw_index = 0
+        seed = int(Time.get_unix_time_from_system())
+        Config.load_all()
+        chosen_variants = {}
+        deck = []
+        draw_index = 0
+        finalize_after_draft()
 
 func finalize_after_draft() -> void:
 	var distribution : Dictionary = {}


### PR DESCRIPTION
## Summary
- build the run deck as part of RunState.start_new_run so the game begins with a full stack of tiles
- reuse the existing finalize_after_draft logic to populate the deck with fallback variants when no draft choices are present

## Testing
- godot --headless --test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e460c3f8a883228e64feba26ceb7fb