### PR TITLE
Ensure build palette window centers correctly

### DIFF
--- a/scenes/BuildPalette.tscn
+++ b/scenes/BuildPalette.tscn
@@ -5,15 +5,13 @@
 [node name="BuildPalette" type="Control"]
 visible = false
 layout_mode = 3
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -200.0
-offset_top = -140.0
-offset_right = 200.0
-offset_bottom = 140.0
+anchors_preset = 0
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+offset_right = 400.0
+offset_bottom = 280.0
 script = ExtResource("1_5ux0s")
 
 [node name="Panel" type="Panel" parent="."]

--- a/scripts/ui/BuildPalette.gd
+++ b/scripts/ui/BuildPalette.gd
@@ -64,6 +64,7 @@ func _create_labels() -> void:
     _refresh_counts()
     _refresh_in_hand_visuals(_palette_state.get_in_hand_type())
     _refresh_label_tooltips()
+    call_deferred("_center_on_screen")
 
 func _refresh_counts() -> void:
     for cell_type in _labels.keys():
@@ -89,6 +90,7 @@ func _on_palette_opened() -> void:
     _refresh_selection_visuals(_palette_state.get_selected_type())
     _refresh_counts()
     _refresh_in_hand_visuals(_palette_state.get_in_hand_type())
+    call_deferred("_center_on_screen")
 
 func _on_palette_closed() -> void:
     visible = false
@@ -136,4 +138,8 @@ func _center_on_screen() -> void:
     if not _viewport:
         return
     var viewport_size := _viewport.get_visible_rect().size
-    position = viewport_size * 0.5 - size * 0.5
+    var control_size := size
+    if control_size == Vector2.ZERO:
+        control_size = get_combined_minimum_size()
+    var centered_position := (viewport_size - control_size) * 0.5
+    position = centered_position


### PR DESCRIPTION
## Summary
- update the build palette scene anchors so the control can be positioned explicitly
- adjust the palette script to recenter after layout changes and compute a safe centered position

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e47c11a810832288fd1ce94969460d