### PR TITLE
Implement resource tracking and turn capacity logic

### DIFF
--- a/scenes/ui/ResourcesPanel.tscn
+++ b/scenes/ui/ResourcesPanel.tscn
@@ -1,0 +1,84 @@
+[gd_scene load_steps=2 format=3 uid="uid://resourcespanel"]
+
+[ext_resource type="Script" path="res://src/ui/ResourcesPanel.gd" id="1_k0v1n"]
+
+[node name="ResourcesPanel" type="Control"]
+anchors_preset = 0
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 16.0
+offset_top = -220.0
+offset_right = 240.0
+offset_bottom = -16.0
+script = ExtResource("1_k0v1n")
+
+[node name="Panel" type="Panel" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
+self_modulate = Color(1, 1, 1, 0.9)
+
+[node name="Margin" type="MarginContainer" parent="Panel"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 12.0
+offset_top = 12.0
+offset_right = -12.0
+offset_bottom = -12.0
+
+[node name="VBox" type="VBoxContainer" parent="Panel/Margin"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
+separation = 8
+
+[node name="Title" type="Label" parent="Panel/Margin/VBox"]
+text = "Resources"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Grid" type="GridContainer" parent="Panel/Margin/VBox"]
+columns = 2
+custom_constants/vertical_separation = 4
+custom_constants/horizontal_separation = 12
+
+[node name="NatureLabel" type="Label" parent="Panel/Margin/VBox/Grid"]
+text = "Nature"
+
+[node name="NatureValue" type="Label" parent="Panel/Margin/VBox/Grid"]
+unique_name_in_owner = true
+text = "0"
+horizontal_alignment = 2
+
+[node name="EarthLabel" type="Label" parent="Panel/Margin/VBox/Grid"]
+text = "Earth"
+
+[node name="EarthValue" type="Label" parent="Panel/Margin/VBox/Grid"]
+unique_name_in_owner = true
+text = "0"
+horizontal_alignment = 2
+
+[node name="WaterLabel" type="Label" parent="Panel/Margin/VBox/Grid"]
+text = "Water"
+
+[node name="WaterValue" type="Label" parent="Panel/Margin/VBox/Grid"]
+unique_name_in_owner = true
+text = "0"
+horizontal_alignment = 2
+
+[node name="LifeLabel" type="Label" parent="Panel/Margin/VBox/Grid"]
+text = "Life"
+
+[node name="LifeValue" type="Label" parent="Panel/Margin/VBox/Grid"]
+unique_name_in_owner = true
+text = "0"
+horizontal_alignment = 2

--- a/src/systems/Clusters.gd
+++ b/src/systems/Clusters.gd
@@ -1,0 +1,55 @@
+extends RefCounted
+## Identifies contiguous clusters of tiles by category on a hex grid.
+class_name Clusters
+
+const Hex := preload("res://src/core/Hex.gd")
+
+static func collect(grid: Dictionary, category: String) -> Array:
+        var clusters: Array = []
+        var target := category
+        var visited: Dictionary = {}
+        for key in grid.keys():
+                var axial := _to_vector2i(key)
+                if visited.has(axial):
+                        continue
+                var tile_category := str(_get_category(grid.get(key)))
+                if tile_category != target:
+                        continue
+                clusters.append(_flood_fill(grid, axial, target, visited))
+        return clusters
+
+static func _flood_fill(grid: Dictionary, start: Vector2i, category: String, visited: Dictionary) -> Array:
+        var cluster: Array = []
+        var frontier: Array = [start]
+        visited[start] = true
+        while frontier.size() > 0:
+                var current: Vector2i = frontier[0]
+                frontier.remove_at(0)
+                cluster.append(current)
+                for neighbor in Hex.neighbors(Hex.Axial.from_vector2i(current)):
+                        var vec := neighbor.to_vector2i()
+                        if visited.has(vec):
+                                continue
+                        if not grid.has(vec):
+                                continue
+                        if str(_get_category(grid.get(vec))) != category:
+                                continue
+                        visited[vec] = true
+                        frontier.append(vec)
+        return cluster
+
+static func _get_category(tile_data: Variant) -> String:
+        if typeof(tile_data) == TYPE_DICTIONARY:
+                return String(tile_data.get("category", ""))
+        if typeof(tile_data) == TYPE_STRING:
+                return String(tile_data)
+        return ""
+
+static func _to_vector2i(value: Variant) -> Vector2i:
+        if value is Vector2i:
+                return value
+        if value is Hex.Axial:
+                return value.to_vector2i()
+        if typeof(value) == TYPE_DICTIONARY and value.has("q") and value.has("r"):
+                return Vector2i(int(value.q), int(value.r))
+        return Vector2i.ZERO

--- a/src/systems/ProducerRefine.gd
+++ b/src/systems/ProducerRefine.gd
@@ -1,0 +1,53 @@
+extends RefCounted
+## Handles conversion of Nature and Earth into Water for refine tiles.
+class_name ProducerRefine
+
+const Resources := preload("res://src/systems/Resources.gd")
+const Hex := preload("res://src/core/Hex.gd")
+
+var cooldown_turns: int = 2
+var _cooldowns: Dictionary = {}
+
+func process_turn(tiles: Array, resources: Resources) -> void:
+        var active: Dictionary = {}
+        for entry in tiles:
+                var axial := _to_vector2i(entry)
+                active[axial] = true
+                var remaining := int(_cooldowns.get(axial, cooldown_turns))
+                remaining -= 1
+                if remaining <= 0:
+                        if _try_convert(resources):
+                                remaining = cooldown_turns
+                        else:
+                                remaining = 1
+                _cooldowns[axial] = remaining
+        var to_remove: Array = []
+        for key in _cooldowns.keys():
+                if not active.has(key):
+                        to_remove.append(key)
+        for key in to_remove:
+                _cooldowns.erase(key)
+
+func _try_convert(resources: Resources) -> bool:
+        if not resources:
+                return false
+        if not resources.has_amount("nature", 1):
+                return false
+        if not resources.has_amount("earth", 1):
+                return false
+        if not resources.consume("nature", 1):
+                return false
+        if not resources.consume("earth", 1):
+                resources.add("nature", 1)
+                return false
+        resources.add("water", 1)
+        return true
+
+static func _to_vector2i(value: Variant) -> Vector2i:
+        if value is Vector2i:
+                return value
+        if value is Hex.Axial:
+                return value.to_vector2i()
+        if typeof(value) == TYPE_DICTIONARY and value.has("q") and value.has("r"):
+                return Vector2i(int(value.q), int(value.r))
+        return Vector2i.ZERO

--- a/src/systems/Resources.gd
+++ b/src/systems/Resources.gd
@@ -1,0 +1,112 @@
+extends RefCounted
+## Tracks core essence resources with capacity limits and change notifications.
+class_name Resources
+
+signal resource_changed(resource_type: String, amount: int, cap: int)
+signal resources_reset
+
+const RESOURCE_TYPES := ["nature", "earth", "water", "life"]
+
+var _data: Dictionary = {}
+
+func _init() -> void:
+        for key in RESOURCE_TYPES:
+                _data[key] = {"amount": 0, "cap": 0}
+
+func reset() -> void:
+        for key in RESOURCE_TYPES:
+                var entry: Dictionary = _data[key]
+                entry["amount"] = 0
+                entry["cap"] = 0
+                _emit_change(key, entry)
+        emit_signal("resources_reset")
+
+func add(resource_type: String, delta: int) -> int:
+        var key := _normalize(resource_type)
+        var entry := _ensure_entry(key)
+        var amount: int = int(entry.get("amount", 0))
+        var cap: int = int(entry.get("cap", 0))
+        var new_amount := amount + delta
+        if new_amount < 0:
+                new_amount = 0
+        if key != "life":
+                if cap <= 0:
+                        new_amount = 0
+                else:
+                        new_amount = clamp(new_amount, 0, cap)
+        entry["amount"] = new_amount
+        _emit_change(key, entry)
+        return new_amount
+
+func consume(resource_type: String, amount: int) -> bool:
+        if amount <= 0:
+                return true
+        var key := _normalize(resource_type)
+        var entry := _ensure_entry(key)
+        var current: int = int(entry.get("amount", 0))
+        if current < amount:
+                return false
+        entry["amount"] = current - amount
+        _emit_change(key, entry)
+        return true
+
+func has_amount(resource_type: String, amount: int) -> bool:
+        if amount <= 0:
+                return true
+        var key := _normalize(resource_type)
+        var entry := _ensure_entry(key)
+        return int(entry.get("amount", 0)) >= amount
+
+func set_cap_delta(resource_type: String, delta: int) -> int:
+        var key := _normalize(resource_type)
+        var entry := _ensure_entry(key)
+        var cap: int = int(entry.get("cap", 0))
+        var new_cap := max(0, cap + delta)
+        if new_cap == cap:
+                return cap
+        entry["cap"] = new_cap
+        if key != "life":
+                if new_cap <= 0:
+                        entry["amount"] = 0
+                else:
+                        entry["amount"] = min(int(entry.get("amount", 0)), new_cap)
+        _emit_change(key, entry)
+        return new_cap
+
+func set_cap(resource_type: String, value: int) -> int:
+        var key := _normalize(resource_type)
+        _ensure_entry(key)
+        var cap: int = int(_data[key].get("cap", 0))
+        return set_cap_delta(key, value - cap)
+
+func get_amount(resource_type: String) -> int:
+        var key := _normalize(resource_type)
+        var entry := _ensure_entry(key)
+        return int(entry.get("amount", 0))
+
+func get_cap(resource_type: String) -> int:
+        var key := _normalize(resource_type)
+        var entry := _ensure_entry(key)
+        return int(entry.get("cap", 0))
+
+func get_entry(resource_type: String) -> Dictionary:
+        var key := _normalize(resource_type)
+        var entry := _ensure_entry(key)
+        return {"amount": int(entry.get("amount", 0)), "cap": int(entry.get("cap", 0))}
+
+func get_all() -> Dictionary:
+        var copy := {}
+        for key in RESOURCE_TYPES:
+                copy[key] = get_entry(key)
+        return copy
+
+func _ensure_entry(resource_type: String) -> Dictionary:
+        if not _data.has(resource_type):
+                _data[resource_type] = {"amount": 0, "cap": 0}
+        return _data[resource_type]
+
+func _normalize(resource_type: String) -> String:
+        return resource_type.to_lower()
+
+func _emit_change(resource_type: String, entry: Dictionary) -> void:
+        emit_signal("resource_changed", resource_type, int(entry.get("amount", 0)), int(entry.get("cap", 0)))

--- a/src/systems/TurnController.gd
+++ b/src/systems/TurnController.gd
@@ -1,0 +1,75 @@
+extends RefCounted
+## Coordinates end-of-turn updates for resources and tile-based systems.
+class_name TurnController
+
+const Hex := preload("res://src/core/Hex.gd")
+const Resources := preload("res://src/systems/Resources.gd")
+const Clusters := preload("res://src/systems/Clusters.gd")
+const ProducerRefine := preload("res://src/systems/ProducerRefine.gd")
+
+const PRODUCER_RESOURCE := {
+        "Harvest": "nature",
+        "Build": "earth",
+        "Refine": "water",
+}
+
+var resources: Resources
+var _grid: Dictionary = {}
+var _producer_refine: ProducerRefine
+
+func _init() -> void:
+        resources = Resources.new()
+        _producer_refine = ProducerRefine.new()
+
+func set_tile(axial: Vector2i, category: String) -> void:
+        if category == "" or category == null:
+                _grid.erase(axial)
+                return
+        _grid[axial] = {"category": category}
+
+func remove_tile(axial: Vector2i) -> void:
+        _grid.erase(axial)
+
+func end_turn() -> void:
+        _recompute_capacity()
+        _process_refine()
+
+func _recompute_capacity() -> void:
+        var caps := {
+                "nature": 0,
+                "earth": 0,
+                "water": 0,
+                "life": resources.get_cap("life"),
+        }
+        for key in _grid.keys():
+                var category := str(_grid[key].get("category", ""))
+                if PRODUCER_RESOURCE.has(category):
+                        var res_type: String = PRODUCER_RESOURCE[category]
+                        caps[res_type] = caps.get(res_type, 0) + 5
+        var harvest_clusters := Clusters.collect(_grid, "Harvest")
+        for cluster in harvest_clusters:
+                caps["nature"] = caps.get("nature", 0) + cluster.size() * 10
+        var storage_positions := _positions_for_category("Storage")
+        for storage_pos in storage_positions:
+                for neighbor in Hex.neighbors(Hex.Axial.from_vector2i(storage_pos)):
+                        var neighbor_vec := neighbor.to_vector2i()
+                        if not _grid.has(neighbor_vec):
+                                continue
+                        var neighbor_category := str(_grid[neighbor_vec].get("category", ""))
+                        if PRODUCER_RESOURCE.has(neighbor_category):
+                                var res_key: String = PRODUCER_RESOURCE[neighbor_category]
+                                caps[res_key] = caps.get(res_key, 0) + 5
+        for key in caps.keys():
+                resources.set_cap(key, int(caps[key]))
+
+func _process_refine() -> void:
+        var refine_positions := _positions_for_category("Refine")
+        _producer_refine.process_turn(refine_positions, resources)
+
+func _positions_for_category(category: String) -> Array:
+        var results: Array = []
+        for key in _grid.keys():
+                var tile_category := str(_grid[key].get("category", ""))
+                if tile_category == category:
+                        results.append(key)
+        return results

--- a/src/ui/ResourcesPanel.gd
+++ b/src/ui/ResourcesPanel.gd
@@ -1,0 +1,72 @@
+extends Control
+## Displays core resource totals and capacity information.
+class_name ResourcesPanel
+
+const Resources := preload("res://src/systems/Resources.gd")
+const PanelSwitcher := preload("res://src/ui/PanelSwitcher.gd")
+
+@export var panel_switcher_path: NodePath
+
+var _resources: Resources
+var _labels: Dictionary = {}
+
+func _ready() -> void:
+        _labels = {
+                "nature": get_node_or_null("%NatureValue"),
+                "earth": get_node_or_null("%EarthValue"),
+                "water": get_node_or_null("%WaterValue"),
+                "life": get_node_or_null("%LifeValue"),
+        }
+        _register_with_switcher()
+        _refresh_all()
+
+func set_resources(resources: Resources) -> void:
+        if _resources == resources:
+                return
+        var callback := Callable(self, "_on_resource_changed")
+        if _resources and _resources.resource_changed.is_connected(callback):
+                _resources.resource_changed.disconnect(callback)
+        _resources = resources
+        if _resources and not _resources.resource_changed.is_connected(callback):
+                _resources.resource_changed.connect(callback)
+        _refresh_all()
+
+func _register_with_switcher() -> void:
+        var switcher := _resolve_panel_switcher()
+        if switcher:
+                switcher.register_panel("Resources", self)
+
+func _resolve_panel_switcher() -> PanelSwitcher:
+        if panel_switcher_path != NodePath():
+                var node := get_node_or_null(panel_switcher_path)
+                if node is PanelSwitcher:
+                        return node
+        var current := get_parent()
+        while current:
+                if current is PanelSwitcher:
+                        return current
+                current = current.get_parent()
+        return null
+
+func _refresh_all() -> void:
+        if not _resources:
+                _update_label("nature", 0, 0)
+                _update_label("earth", 0, 0)
+                _update_label("water", 0, 0)
+                _update_label("life", 0, 0)
+                return
+        for key in _labels.keys():
+                var entry := _resources.get_entry(key)
+                _update_label(key, int(entry.get("amount", 0)), int(entry.get("cap", 0)))
+
+func _on_resource_changed(resource_type: String, amount: int, cap: int) -> void:
+        _update_label(resource_type, amount, cap)
+
+func _update_label(resource_type: String, amount: int, cap: int) -> void:
+        var label: Label = _labels.get(resource_type, null)
+        if not label:
+                return
+        if resource_type == "life" or cap <= 0:
+                label.text = str(amount)
+        else:
+                label.text = "%d/%d" % [amount, cap]

--- a/tests/run_tests.gd
+++ b/tests/run_tests.gd
@@ -7,6 +7,7 @@ const TEST_SCRIPTS := [
         preload("res://tests/test_tiletypes.gd"),
         preload("res://tests/test_draft_logic.gd"),
         preload("res://tests/test_deck_build.gd"),
+        preload("res://tests/test_resources_systems.gd"),
 ]
 
 func _init() -> void:

--- a/tests/test_resources_systems.gd
+++ b/tests/test_resources_systems.gd
@@ -1,0 +1,64 @@
+extends RefCounted
+
+const Resources := preload("res://src/systems/Resources.gd")
+const TurnController := preload("res://src/systems/TurnController.gd")
+
+func test_resource_clamp_to_cap() -> bool:
+        var resources := Resources.new()
+        resources.set_cap("nature", 10)
+        resources.add("nature", 15)
+        if resources.get_amount("nature") != 10:
+                push_error("Nature should clamp to cap of 10")
+                return false
+        resources.add("nature", -20)
+        if resources.get_amount("nature") != 0:
+                push_error("Nature should not drop below zero")
+                return false
+        return true
+
+func test_harvest_cluster_capacity_bonus() -> bool:
+        var controller := TurnController.new()
+        controller.set_tile(Vector2i(0, 0), "Harvest")
+        controller.set_tile(Vector2i(1, 0), "Harvest")
+        controller.set_tile(Vector2i(0, 1), "Harvest")
+        controller.end_turn()
+        var expected := 3 * 5 + 3 * 10
+        var cap := controller.resources.get_cap("nature")
+        if cap != expected:
+                push_error("Expected nature cap %d, got %d" % [expected, cap])
+                return false
+        return true
+
+func test_storage_adjacent_bonus_applies_once_per_neighbor() -> bool:
+        var controller := TurnController.new()
+        controller.set_tile(Vector2i(0, 0), "Harvest")
+        controller.end_turn()
+        var baseline := controller.resources.get_cap("nature")
+        controller.set_tile(Vector2i(1, 0), "Storage")
+        controller.end_turn()
+        var with_storage := controller.resources.get_cap("nature")
+        if with_storage != baseline + 5:
+                push_error("Storage adjacency should add +5 nature capacity (baseline=%d, got=%d)" % [baseline, with_storage])
+                return false
+        return true
+
+func test_refine_converts_every_two_turns() -> bool:
+        var controller := TurnController.new()
+        controller.set_tile(Vector2i(0, 0), "Harvest")
+        controller.set_tile(Vector2i(1, 0), "Build")
+        controller.set_tile(Vector2i(0, 1), "Refine")
+        controller.end_turn()
+        controller.resources.add("nature", 2)
+        controller.resources.add("earth", 2)
+        controller.end_turn()
+        var water := controller.resources.get_amount("water")
+        if water != 1:
+                push_error("Expected water to increase by 1 after two turns, got %d" % water)
+                return false
+        if controller.resources.get_amount("nature") != 1:
+                push_error("Nature should have been reduced to 1")
+                return false
+        if controller.resources.get_amount("earth") != 1:
+                push_error("Earth should have been reduced to 1")
+                return false
+        return true


### PR DESCRIPTION
## Summary
- add a reusable Resources model with cap-aware adjustments and panel UI
- recompute per-turn capacity bonuses from harvest clusters, storage adjacency, and refine cooldowns
- cover the new systems with dedicated unit tests

## Testing
- godot4 --headless --quiet --path . --script tests/run_tests.gd *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e4829e0df48322ada56e462d047cd1