### PR TITLE
Implement overgrowth enclosure, growth, and mutation systems

### DIFF
--- a/src/core/RunState.gd
+++ b/src/core/RunState.gd
@@ -6,14 +6,18 @@ var seed:int = 0
 var chosen_variants:Dictionary = {}
 var deck:Array = []
 var draw_index:int = 0
+var overgrowth:Dictionary = {}
+var connected_set:Dictionary = {}
 
 func start_new_run() -> void:
-		seed = int(Time.get_unix_time_from_system())
-		Config.load_all()
-		chosen_variants = {}
-		deck = []
-		draw_index = 0
-		finalize_after_draft()
+                seed = int(Time.get_unix_time_from_system())
+                Config.load_all()
+                chosen_variants = {}
+                deck = []
+                draw_index = 0
+                overgrowth = {}
+                connected_set = {}
+                finalize_after_draft()
 
 func finalize_after_draft() -> void:
 	var distribution : Dictionary = {}

--- a/src/systems/Board.gd
+++ b/src/systems/Board.gd
@@ -1,0 +1,41 @@
+extends Node
+## Minimal board data container used for tests and turn processing.
+class_name Board
+
+var placed_tiles: Dictionary = {}
+
+static func key(axial: Vector2i) -> String:
+        return "%d,%d" % [axial.x, axial.y]
+
+static func unkey(k: String) -> Vector2i:
+        var parts := k.split(",")
+        return Vector2i(int(parts[0]), int(parts[1]))
+
+func add_tile(axial: Vector2i, category: String, variant_id: String) -> void:
+        placed_tiles[key(axial)] = {
+                "category": category,
+                "variant_id": variant_id,
+                "flags": {},
+        }
+        _render_tile(axial, category, variant_id)
+
+func replace_tile(axial: Vector2i, category: String, variant_id: String) -> void:
+        placed_tiles[key(axial)] = {
+                "category": category,
+                "variant_id": variant_id,
+                "flags": {},
+        }
+        _render_tile(axial, category, variant_id)
+
+func remove_tile(axial: Vector2i) -> void:
+        placed_tiles.erase(key(axial))
+
+func get_tile(axial: Vector2i) -> Dictionary:
+        return placed_tiles.get(key(axial), {})
+
+func has_tile(axial: Vector2i) -> bool:
+        return placed_tiles.has(key(axial))
+
+func _render_tile(_axial: Vector2i, _category: String, _variant_id: String) -> void:
+        # Rendering is handled elsewhere in the main project; tests only require the data state.
+        pass

--- a/src/systems/Enclosure.gd
+++ b/src/systems/Enclosure.gd
@@ -1,0 +1,93 @@
+extends Node
+class_name Enclosure
+
+const RunState := preload("res://src/core/RunState.gd")
+
+static func axial_neighbors(ax: Vector2i) -> Array:
+        var dirs := [Vector2i(+1, 0), Vector2i(+1, -1), Vector2i(0, -1), Vector2i(-1, 0), Vector2i(-1, +1), Vector2i(0, +1)]
+        var out: Array = []
+        for d in dirs:
+                out.append(ax + d)
+        return out
+
+static func key(ax: Vector2i) -> String:
+        return "%d,%d" % [ax.x, ax.y]
+
+static func detect_and_mark_overgrowth(board: Node) -> void:
+        var coords: Array = []
+        for k in board.placed_tiles.keys():
+                coords.append(_unkey(k))
+        if coords.is_empty():
+                return
+
+        var min_q := 999999
+        var max_q := -999999
+        var min_r := 999999
+        var max_r := -999999
+        for ax in coords:
+                min_q = min(min_q, ax.x)
+                max_q = max(max_q, ax.x)
+                min_r = min(min_r, ax.y)
+                max_r = max(max_r, ax.y)
+        min_q -= 1
+        max_q += 1
+        min_r -= 1
+        max_r += 1
+
+        var placed := {}
+        for k in board.placed_tiles.keys():
+                placed[k] = true
+        var og := {}
+        for k in RunState.overgrowth.keys():
+                og[k] = true
+
+        func is_empty(ax: Vector2i) -> bool:
+                var k := key(ax)
+                return (not placed.has(k)) and (not og.has(k))
+
+        var visited := {}
+        var queue: Array = []
+
+        func enqueue(ax: Vector2i) -> void:
+                var k := key(ax)
+                if visited.has(k):
+                        return
+                queue.append(ax)
+
+        for q in range(min_q, max_q + 1):
+                for r in [min_r, max_r]:
+                        var ax := Vector2i(q, r)
+                        if is_empty(ax):
+                                enqueue(ax)
+        for r in range(min_r, max_r + 1):
+                for q in [min_q, max_q]:
+                        var ax := Vector2i(q, r)
+                        if is_empty(ax):
+                                enqueue(ax)
+
+        while queue.size() > 0:
+                var cur: Vector2i = queue.pop_back()
+                var ck := key(cur)
+                if visited.has(ck):
+                        continue
+                visited[ck] = true
+                for n in axial_neighbors(cur):
+                        if n.x < min_q or n.x > max_q or n.y < min_r or n.y > max_r:
+                                continue
+                        var nk := key(n)
+                        if visited.has(nk):
+                                continue
+                        if is_empty(n):
+                                queue.append(n)
+
+        for q in range(min_q, max_q + 1):
+                for r in range(min_r, max_r + 1):
+                        var ax := Vector2i(q, r)
+                        var k := key(ax)
+                        if is_empty(ax) and not visited.has(k):
+                                if not RunState.overgrowth.has(k):
+                                        RunState.overgrowth[k] = 0
+
+static func _unkey(k: String) -> Vector2i:
+        var parts := k.split(",")
+        return Vector2i(int(parts[0]), int(parts[1]))

--- a/src/systems/Growth.gd
+++ b/src/systems/Growth.gd
@@ -1,0 +1,28 @@
+extends Node
+class_name Growth
+
+const RunState := preload("res://src/core/RunState.gd")
+
+static func key(ax: Vector2i) -> String:
+        return "%d,%d" % [ax.x, ax.y]
+
+static func unkey(k: String) -> Vector2i:
+        var p := k.split(",")
+        return Vector2i(int(p[0]), int(p[1]))
+
+static func do_growth(board: Node) -> void:
+        if RunState.overgrowth.size() == 0:
+                return
+        var to_promote: Array = []
+        var keys: Array = RunState.overgrowth.keys()
+        for k in keys:
+                var current_age := int(RunState.overgrowth[k])
+                current_age += 1
+                RunState.overgrowth[k] = current_age
+                if current_age >= 3:
+                        to_promote.append(k)
+        for k in to_promote:
+                RunState.overgrowth.erase(k)
+                var ax := unkey(k)
+                board.replace_tile(ax, "Grove", "grove_base")
+                RunState.connected_set[k] = true

--- a/src/systems/Mutation.gd
+++ b/src/systems/Mutation.gd
@@ -1,0 +1,33 @@
+extends Node
+class_name Mutation
+
+static func axial_neighbors(ax: Vector2i) -> Array:
+        var dirs := [Vector2i(+1, 0), Vector2i(+1, -1), Vector2i(0, -1), Vector2i(-1, 0), Vector2i(-1, +1), Vector2i(0, +1)]
+        var out: Array = []
+        for d in dirs:
+                out.append(ax + d)
+        return out
+
+static func key(ax: Vector2i) -> String:
+        return "%d,%d" % [ax.x, ax.y]
+
+static func unkey(k: String) -> Vector2i:
+        var p := k.split(",")
+        return Vector2i(int(p[0]), int(p[1]))
+
+static func do_mutations(board: Node) -> void:
+        for k in board.placed_tiles.keys():
+                var t: Dictionary = board.placed_tiles[k]
+                if t.get("category", "") != "Grove":
+                        continue
+                var ax := unkey(k)
+                var has_harvest := false
+                for n in axial_neighbors(ax):
+                        var nk := key(n)
+                        if board.placed_tiles.has(nk) and board.placed_tiles[nk].get("category", "") == "Harvest":
+                                has_harvest = true
+                                break
+                if not t.has("flags"):
+                        t["flags"] = {}
+                t["flags"]["thicket"] = has_harvest
+                board.placed_tiles[k] = t

--- a/tests/run_tests.gd
+++ b/tests/run_tests.gd
@@ -8,6 +8,9 @@ const TEST_SCRIPTS := [
         preload("res://tests/test_draft_logic.gd"),
         preload("res://tests/test_deck_build.gd"),
         preload("res://tests/test_resources_systems.gd"),
+        preload("res://tests/test_enclosure.gd"),
+        preload("res://tests/test_growth_to_grove.gd"),
+        preload("res://tests/test_mutation_grove_thicket.gd"),
 ]
 
 func _init() -> void:

--- a/tests/test_enclosure.gd
+++ b/tests/test_enclosure.gd
@@ -1,0 +1,37 @@
+extends RefCounted
+
+const Board := preload("res://src/systems/Board.gd")
+const Enclosure := preload("res://src/systems/Enclosure.gd")
+const RunState := preload("res://src/core/RunState.gd")
+
+func _ring_positions(center: Vector2i) -> Array:
+        return [
+                center + Vector2i(1, 0),
+                center + Vector2i(1, -1),
+                center + Vector2i(0, -1),
+                center + Vector2i(-1, 0),
+                center + Vector2i(-1, 1),
+                center + Vector2i(0, 1),
+        ]
+
+func _reset_state() -> void:
+        RunState.overgrowth = {}
+        RunState.connected_set = {}
+
+func test_single_hex_enclosure_marks_overgrowth() -> bool:
+        _reset_state()
+        var board := Board.new()
+        var center := Vector2i.ZERO
+        for pos in _ring_positions(center):
+                board.add_tile(pos, "Harvest", "harvest_basic")
+        Enclosure.detect_and_mark_overgrowth(board)
+        var center_key := Board.key(center)
+        if not RunState.overgrowth.has(center_key):
+                return false
+        if int(RunState.overgrowth[center_key]) != 0:
+                return false
+        var first_size := RunState.overgrowth.size()
+        Enclosure.detect_and_mark_overgrowth(board)
+        if RunState.overgrowth.size() != first_size:
+                return false
+        return int(RunState.overgrowth[center_key]) == 0

--- a/tests/test_growth_to_grove.gd
+++ b/tests/test_growth_to_grove.gd
@@ -1,0 +1,33 @@
+extends RefCounted
+
+const Board := preload("res://src/systems/Board.gd")
+const Growth := preload("res://src/systems/Growth.gd")
+const RunState := preload("res://src/core/RunState.gd")
+
+func _reset_state() -> void:
+        RunState.overgrowth = {}
+        RunState.connected_set = {}
+
+func test_overgrowth_matures_into_grove() -> bool:
+        _reset_state()
+        var board := Board.new()
+        var cell := Vector2i.ZERO
+        var key := Board.key(cell)
+        RunState.overgrowth[key] = 0
+        Growth.do_growth(board)
+        if int(RunState.overgrowth[key]) != 1:
+                return false
+        Growth.do_growth(board)
+        if int(RunState.overgrowth[key]) != 2:
+                return false
+        Growth.do_growth(board)
+        if RunState.overgrowth.has(key):
+                return false
+        if not board.placed_tiles.has(key):
+                return false
+        var tile: Dictionary = board.placed_tiles[key]
+        if tile.get("category", "") != "Grove":
+                return false
+        if tile.get("variant_id", "") != "grove_base":
+                return false
+        return RunState.connected_set.has(key)

--- a/tests/test_mutation_grove_thicket.gd
+++ b/tests/test_mutation_grove_thicket.gd
@@ -1,0 +1,23 @@
+extends RefCounted
+
+const Board := preload("res://src/systems/Board.gd")
+const Mutation := preload("res://src/systems/Mutation.gd")
+
+func _make_basic_board() -> Board:
+        var board := Board.new()
+        board.add_tile(Vector2i.ZERO, "Grove", "grove_base")
+        return board
+
+func test_grove_adjacent_to_harvest_sets_thicket() -> bool:
+        var board := _make_basic_board()
+        board.add_tile(Vector2i(1, 0), "Harvest", "harvest_basic")
+        Mutation.do_mutations(board)
+        var grove_data: Dictionary = board.get_tile(Vector2i.ZERO)
+        if not grove_data.has("flags"):
+                return false
+        if not bool(grove_data["flags"].get("thicket", false)):
+                return false
+        board.remove_tile(Vector2i(1, 0))
+        Mutation.do_mutations(board)
+        grove_data = board.get_tile(Vector2i.ZERO)
+        return not bool(grove_data["flags"].get("thicket", false))


### PR DESCRIPTION
## Summary
- extend the run state with overgrowth tracking and provide a lightweight board container
- add enclosure detection, growth promotion, and grove mutation systems
- cover the new behaviour with dedicated unit tests

## Testing
- godot --headless --script tests/run_tests.gd *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68e4898c0c888322837de87d002ffa30