### PR TITLE
Add turn phase bus with review gate and wiring stubs

### DIFF
--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=3 uid="uid://main"]
+[gd_scene load_steps=11 format=3 uid="uid://main"]
 
 [ext_resource type="PackedScene" uid="uid://hexgrid" path="res://scenes/HexGrid.tscn" id="1_kg8yr"]
 [ext_resource type="Script" uid="uid://bb7bx1ydmjot5" path="res://scripts/input/InputController.gd" id="2_buqfh"]
@@ -7,6 +7,9 @@
 [ext_resource type="PackedScene" uid="uid://buildpalette" path="res://scenes/BuildPalette.tscn" id="5_sef0j"]
 [ext_resource type="Script" uid="uid://bkxqon2flwvp2" path="res://scripts/core/RunState.gd" id="6_37f6p"]
 [ext_resource type="PackedScene" uid="uid://runinfopanel" path="res://scenes/ui/RunInfoPanel.tscn" id="7_f9p8j"]
+[ext_resource type="Script" path="res://src/systems/TurnController.gd" id="8_turpc"]
+[ext_resource type="Script" path="res://src/systems/Board.gd" id="9_brd0u"]
+[ext_resource type="PackedScene" path="res://src/ui/ReviewBanner.tscn" id="10_rvbnr"]
 
 [node name="Main" type="Node2D"]
 script = ExtResource("3_p3b4o")
@@ -35,12 +38,22 @@ script = ExtResource("4_k4cvo")
 grow_horizontal = 2
 grow_vertical = 2
 
+[node name="Board" type="Node" parent="."]
+script = ExtResource("9_brd0u")
+
+[node name="TurnController" type="Node" parent="."]
+script = ExtResource("8_turpc")
+
 [node name="RunState" type="Node" parent="."]
 script = ExtResource("6_37f6p")
 hex_grid_path = NodePath("../HexGrid")
 palette_state_path = NodePath("../PaletteState")
 build_palette_path = NodePath("../BuildPalette")
 info_panel_path = NodePath("../RunInfoPanel")
+
+[node name="UI" type="CanvasLayer" parent="."]
+
+[node name="ReviewBanner" parent="UI" instance=ExtResource("10_rvbnr")]
 
 [node name="RunInfoPanel" parent="." instance=ExtResource("7_f9p8j")]
 layout_mode = 3

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -1,11 +1,38 @@
 extends Node2D
 
 const HexGrid := preload("res://scripts/grid/HexGrid.gd")
+const Enclosure := preload("res://src/systems/Enclosure.gd")
+const Growth := preload("res://src/systems/Growth.gd")
+const Mutation := preload("res://src/systems/Mutation.gd")
+const ResourcesSystem := preload("res://src/systems/Resources.gd")
+const Decay := preload("res://src/systems/Decay.gd")
+const Battle := preload("res://src/systems/Battle.gd")
+const RunState := preload("res://src/core/RunState.gd")
+const TurnController := preload("res://src/systems/TurnController.gd")
+const ReviewBanner := preload("res://src/ui/ReviewBanner.gd")
 
 @onready var background: ColorRect = $Background
 @onready var hex_grid: HexGrid = $HexGrid
+@onready var board: Node = $Board
+@onready var turn_controller: TurnController = $TurnController
+@onready var review_banner: ReviewBanner = $UI/ReviewBanner
 
 func _ready() -> void:
-	if hex_grid and hex_grid.grid_config:
-		background.color = hex_grid.grid_config.background_color
-	hex_grid.position = get_viewport_rect().size * 0.5
+        if hex_grid and hex_grid.grid_config:
+                background.color = hex_grid.grid_config.background_color
+        hex_grid.position = get_viewport_rect().size * 0.5
+        _wire_turn_systems()
+
+func _wire_turn_systems() -> void:
+        if not turn_controller:
+                return
+        if board:
+                turn_controller.subscribe("phase_new_tile", func(): Enclosure.detect_and_mark_overgrowth(board))
+                turn_controller.subscribe("phase_growth", func(): Growth.do_growth(board))
+                turn_controller.subscribe("phase_mutation", func(): Mutation.do_mutations(board))
+                turn_controller.subscribe("phase_resources", func(): ResourcesSystem.do_production(board))
+                turn_controller.subscribe("phase_decay", func(): Decay.do_spread(board))
+                turn_controller.subscribe("phase_battle", func(): Battle.resolve_all(board))
+        if review_banner:
+                review_banner.turn_controller = turn_controller
+                turn_controller.subscribe("phase_review", func(): review_banner.show_for_turn(RunState.turn))

--- a/scripts/input/InputController.gd
+++ b/scripts/input/InputController.gd
@@ -3,12 +3,15 @@ extends Node
 ## Handles keyboard input and forwards navigation and build commands.
 @export var hex_grid_path: NodePath
 @export var run_state_path: NodePath
+@export var turn_controller_path: NodePath
 
 const HexGrid := preload("res://scripts/grid/HexGrid.gd")
 const RunStateController := preload("res://scripts/core/RunState.gd")
+const TurnController := preload("res://src/systems/TurnController.gd")
 
 var _hex_grid: HexGrid
 var _run_state: RunStateController
+var _turn_controller: TurnController
 
 const MOVE_VECTORS := {
 		"ui_left": Vector2i(-1, 0),
@@ -20,15 +23,20 @@ const MOVE_VECTORS := {
 func _ready() -> void:
 		if hex_grid_path.is_empty():
 				hex_grid_path = NodePath("../HexGrid")
-		if run_state_path.is_empty():
-				run_state_path = NodePath("../RunState")
+                if run_state_path.is_empty():
+                                run_state_path = NodePath("../RunState")
+                if turn_controller_path.is_empty():
+                                turn_controller_path = NodePath("../TurnController")
 
-		_hex_grid = get_node_or_null(hex_grid_path)
-		if not _hex_grid:
-				push_warning("InputController could not find HexGrid node at %s" % hex_grid_path)
-		_run_state = get_node_or_null(run_state_path)
-		if not _run_state:
-				push_warning("InputController could not find RunState node at %s" % run_state_path)
+                _hex_grid = get_node_or_null(hex_grid_path)
+                if not _hex_grid:
+                                push_warning("InputController could not find HexGrid node at %s" % hex_grid_path)
+                _run_state = get_node_or_null(run_state_path)
+                if not _run_state:
+                                push_warning("InputController could not find RunState node at %s" % run_state_path)
+                _turn_controller = get_node_or_null(turn_controller_path)
+                if not _turn_controller:
+                                push_warning("InputController could not find TurnController node at %s" % turn_controller_path)
 
 func _unhandled_input(event: InputEvent) -> void:
 		if not _hex_grid:
@@ -41,10 +49,13 @@ func _unhandled_input(event: InputEvent) -> void:
 						get_viewport().set_input_as_handled()
 						return
 
-		if event.is_action_pressed("ui_accept"):
-				if _run_state and not _run_state.is_deck_empty():
-						var axial := _hex_grid.get_cursor_axial()
-						_hex_grid.clear_all_highlights()
+                if event.is_action_pressed("ui_accept"):
+                                if _turn_controller and _turn_controller.is_in_review:
+                                                get_viewport().set_input_as_handled()
+                                                return
+                                if _run_state and not _run_state.is_deck_empty():
+                                                var axial := _hex_grid.get_cursor_axial()
+                                                _hex_grid.clear_all_highlights()
 						var placed: bool = _run_state.try_place_tile(axial)
 						if not placed:
 								_hex_grid.highlight_cell(axial, true)

--- a/src/core/RunState.gd
+++ b/src/core/RunState.gd
@@ -3,6 +3,7 @@ extends Node
 const Deck := preload("res://src/systems/Deck.gd")
 
 var seed:int = 0
+var turn:int = 0
 var chosen_variants:Dictionary = {}
 var deck:Array = []
 var draw_index:int = 0
@@ -17,6 +18,7 @@ func start_new_run() -> void:
                 draw_index = 0
                 overgrowth = {}
                 connected_set = {}
+                turn = 0
                 finalize_after_draft()
 
 func finalize_after_draft() -> void:

--- a/src/systems/Battle.gd
+++ b/src/systems/Battle.gd
@@ -1,0 +1,5 @@
+extends Node
+class_name Battle
+
+static func resolve_all(_board: Node) -> void:
+        print_debug("Battle.resolve_all() — stub")

--- a/src/systems/Decay.gd
+++ b/src/systems/Decay.gd
@@ -1,0 +1,5 @@
+extends Node
+class_name Decay
+
+static func do_spread(_board: Node) -> void:
+        print_debug("Decay.do_spread() — stub")

--- a/src/systems/Resources.gd
+++ b/src/systems/Resources.gd
@@ -7,6 +7,10 @@ signal resources_reset
 
 const RESOURCE_TYPES := ["nature", "earth", "water", "life"]
 
+static func do_production(_board: Node) -> void:
+        # TODO (Phase 4): clusters, storage capacity, refine cooldown conversions, etc.
+        print_debug("Resources.do_production() — stub")
+
 var _data: Dictionary = {}
 
 func _init() -> void:

--- a/src/systems/TurnController.gd
+++ b/src/systems/TurnController.gd
@@ -1,25 +1,96 @@
-extends RefCounted
-## Coordinates end-of-turn updates for resources and tile-based systems.
+extends Node
+## Coordinates turn phase flow and exposes a lightweight phase bus.
 class_name TurnController
 
+signal phase_new_tile
+signal phase_growth
+signal phase_mutation
+signal phase_resources
+signal phase_decay
+signal phase_battle
+signal phase_review
+
+const RunState := preload("res://src/core/RunState.gd")
 const Hex := preload("res://src/core/Hex.gd")
-const Resources := preload("res://src/systems/Resources.gd")
+const ResourcesSystem := preload("res://src/systems/Resources.gd")
 const Clusters := preload("res://src/systems/Clusters.gd")
 const ProducerRefine := preload("res://src/systems/ProducerRefine.gd")
 
 const PRODUCER_RESOURCE := {
-        "Harvest": "nature",
-        "Build": "earth",
-        "Refine": "water",
+"Harvest": "nature",
+"Build": "earth",
+"Refine": "water",
 }
 
-var resources: Resources
+var resources: ResourcesSystem
 var _grid: Dictionary = {}
 var _producer_refine: ProducerRefine
 
+var _subscribers := {
+        "phase_new_tile": [],
+        "phase_growth": [],
+        "phase_mutation": [],
+        "phase_resources": [],
+        "phase_decay": [],
+        "phase_battle": [],
+        "phase_review": [],
+}
+
+var is_advancing := false
+var is_in_review := false
+
 func _init() -> void:
-        resources = Resources.new()
+        resources = ResourcesSystem.new()
         _producer_refine = ProducerRefine.new()
+        # Preserve legacy resource processing for tests and tooling.
+        subscribe("phase_resources", Callable(self, "_legacy_process_resources_phase"))
+
+func subscribe(phase: String, callable: Callable) -> void:
+        if not _subscribers.has(phase):
+                push_warning("Unknown phase: %s" % phase)
+                return
+        _subscribers[phase].append(callable)
+
+func unsubscribe(phase: String, callable: Callable) -> void:
+        if not _subscribers.has(phase):
+                return
+        _subscribers[phase].erase(callable)
+
+func _emit_phase(phase: String) -> void:
+        emit_signal(phase)
+        var listeners: Array = _subscribers.get(phase, [])
+        for listener in listeners:
+                if listener is Callable and listener.is_valid():
+                        listener.call()
+
+func end_turn() -> void:
+        if is_advancing or is_in_review:
+                return
+        is_advancing = true
+        RunState.turn += 1
+        var tree := get_tree()
+        var phases := [
+                "phase_new_tile",
+                "phase_growth",
+                "phase_mutation",
+                "phase_resources",
+                "phase_decay",
+                "phase_battle",
+        ]
+        for phase in phases:
+                _emit_phase(phase)
+                if tree:
+                        await tree.process_frame
+        is_in_review = true
+        _emit_phase("phase_review")
+        if tree:
+                await tree.process_frame
+        is_advancing = false
+
+func ack_review_and_resume() -> void:
+        if not is_in_review:
+                return
+        is_in_review = false
 
 func set_tile(axial: Vector2i, category: String) -> void:
         if category == "" or category == null:
@@ -30,7 +101,7 @@ func set_tile(axial: Vector2i, category: String) -> void:
 func remove_tile(axial: Vector2i) -> void:
         _grid.erase(axial)
 
-func end_turn() -> void:
+func _legacy_process_resources_phase() -> void:
         _recompute_capacity()
         _process_refine()
 

--- a/src/ui/ReviewBanner.gd
+++ b/src/ui/ReviewBanner.gd
@@ -1,0 +1,27 @@
+extends Control
+class_name ReviewBanner
+
+@onready var label: Label = $PanelContainer/MarginContainer/Label
+
+var turn_controller: TurnController
+
+func _ready() -> void:
+        visible = false
+        set_process_unhandled_input(true)
+        mouse_filter = Control.MOUSE_FILTER_IGNORE
+
+func show_for_turn(turn: int) -> void:
+        label.text = "Turn %d — Review (Space to continue)" % turn
+        visible = true
+
+func hide_banner() -> void:
+        visible = false
+
+func _unhandled_input(event: InputEvent) -> void:
+        if not visible:
+                return
+        if event.is_action_pressed("ui_accept"):
+                hide_banner()
+                if turn_controller:
+                        turn_controller.ack_review_and_resume()
+                get_viewport().set_input_as_handled()

--- a/src/ui/ReviewBanner.tscn
+++ b/src/ui/ReviewBanner.tscn
@@ -1,0 +1,42 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://src/ui/ReviewBanner.gd" id="1_ahcsw"]
+
+[node name="ReviewBanner" type="Control"]
+script = ExtResource("1_ahcsw")
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -220.0
+offset_right = 220.0
+offset_top = 16.0
+offset_bottom = 80.0
+visible = false
+mouse_filter = 2
+
+[node name="PanelContainer" type="PanelContainer" parent="."]
+anchors_preset = 8
+anchor_left = 0.0
+anchor_right = 1.0
+anchor_top = 0.0
+anchor_bottom = 1.0
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer"]
+anchors_preset = 15
+anchor_left = 0.0
+anchor_right = 1.0
+anchor_top = 0.0
+anchor_bottom = 1.0
+offset_left = 8.0
+offset_right = -8.0
+offset_top = 8.0
+offset_bottom = -8.0
+
+[node name="Label" type="Label" parent="PanelContainer/MarginContainer"]
+anchors_preset = 15
+anchor_left = 0.0
+anchor_right = 1.0
+anchor_top = 0.0
+anchor_bottom = 1.0
+horizontal_alignment = 1
+vertical_alignment = 1
+text = "Turn 0 — Review (Space to continue)"

--- a/tests/run_tests.gd
+++ b/tests/run_tests.gd
@@ -11,9 +11,13 @@ const TEST_SCRIPTS := [
         preload("res://tests/test_enclosure.gd"),
         preload("res://tests/test_growth_to_grove.gd"),
         preload("res://tests/test_mutation_grove_thicket.gd"),
+        preload("res://tests/test_turn_bus.gd"),
 ]
 
 func _init() -> void:
+        call_deferred("_run_all_tests")
+
+func _run_all_tests() -> void:
         var failed := false
         for script in TEST_SCRIPTS:
                 var test_case := script.new()
@@ -22,6 +26,8 @@ func _init() -> void:
                         if not name.begins_with("test_"):
                                 continue
                         var result = test_case.call(name)
+                        if result is GDScriptFunctionState:
+                                result = await result
                         if result is bool and not result:
                                 failed = true
         quit(failed ? 1 : 0)

--- a/tests/test_resources_systems.gd
+++ b/tests/test_resources_systems.gd
@@ -3,6 +3,18 @@ extends RefCounted
 const Resources := preload("res://src/systems/Resources.gd")
 const TurnController := preload("res://src/systems/TurnController.gd")
 
+func _make_controller() -> TurnController:
+        var controller := TurnController.new()
+        var tree: SceneTree = Engine.get_main_loop()
+        tree.root.add_child(controller)
+        return controller
+
+func _await_turn(controller: TurnController) -> void:
+        var result = controller.end_turn()
+        if result is GDScriptFunctionState:
+                await result
+        controller.ack_review_and_resume()
+
 func test_resource_clamp_to_cap() -> bool:
         var resources := Resources.new()
         resources.set_cap("nature", 10)
@@ -17,48 +29,56 @@ func test_resource_clamp_to_cap() -> bool:
         return true
 
 func test_harvest_cluster_capacity_bonus() -> bool:
-        var controller := TurnController.new()
+        var controller := _make_controller()
         controller.set_tile(Vector2i(0, 0), "Harvest")
         controller.set_tile(Vector2i(1, 0), "Harvest")
         controller.set_tile(Vector2i(0, 1), "Harvest")
-        controller.end_turn()
+        await _await_turn(controller)
         var expected := 3 * 5 + 3 * 10
         var cap := controller.resources.get_cap("nature")
         if cap != expected:
+                controller.queue_free()
                 push_error("Expected nature cap %d, got %d" % [expected, cap])
                 return false
+        controller.queue_free()
         return true
 
 func test_storage_adjacent_bonus_applies_once_per_neighbor() -> bool:
-        var controller := TurnController.new()
+        var controller := _make_controller()
         controller.set_tile(Vector2i(0, 0), "Harvest")
-        controller.end_turn()
+        await _await_turn(controller)
         var baseline := controller.resources.get_cap("nature")
         controller.set_tile(Vector2i(1, 0), "Storage")
-        controller.end_turn()
+        await _await_turn(controller)
         var with_storage := controller.resources.get_cap("nature")
         if with_storage != baseline + 5:
+                controller.queue_free()
                 push_error("Storage adjacency should add +5 nature capacity (baseline=%d, got=%d)" % [baseline, with_storage])
                 return false
+        controller.queue_free()
         return true
 
 func test_refine_converts_every_two_turns() -> bool:
-        var controller := TurnController.new()
+        var controller := _make_controller()
         controller.set_tile(Vector2i(0, 0), "Harvest")
         controller.set_tile(Vector2i(1, 0), "Build")
         controller.set_tile(Vector2i(0, 1), "Refine")
-        controller.end_turn()
+        await _await_turn(controller)
         controller.resources.add("nature", 2)
         controller.resources.add("earth", 2)
-        controller.end_turn()
+        await _await_turn(controller)
         var water := controller.resources.get_amount("water")
         if water != 1:
+                controller.queue_free()
                 push_error("Expected water to increase by 1 after two turns, got %d" % water)
                 return false
         if controller.resources.get_amount("nature") != 1:
+                controller.queue_free()
                 push_error("Nature should have been reduced to 1")
                 return false
         if controller.resources.get_amount("earth") != 1:
+                controller.queue_free()
                 push_error("Earth should have been reduced to 1")
                 return false
+        controller.queue_free()
         return true

--- a/tests/test_turn_bus.gd
+++ b/tests/test_turn_bus.gd
@@ -1,0 +1,156 @@
+extends RefCounted
+
+const TurnController := preload("res://src/systems/TurnController.gd")
+const RunState := preload("res://src/core/RunState.gd")
+
+func _make_controller() -> TurnController:
+        RunState.turn = 0
+        var controller := TurnController.new()
+        var tree: SceneTree = Engine.get_main_loop()
+        tree.root.add_child(controller)
+        return controller
+
+func _record_signal(log: Array, phase: String) -> void:
+        log.append(phase)
+
+func _await_turn(controller: TurnController) -> void:
+        var result = controller.end_turn()
+        if result is GDScriptFunctionState:
+                await result
+
+func test_phase_bus_and_review_gate() -> bool:
+        var controller := _make_controller()
+        var signal_order: Array[String] = []
+        var bus_order: Array[String] = []
+        var reentry_guard := true
+
+        var phases := [
+                "phase_new_tile",
+                "phase_growth",
+                "phase_mutation",
+                "phase_resources",
+                "phase_decay",
+                "phase_battle",
+                "phase_review",
+        ]
+        for phase in phases:
+                controller.connect(phase, Callable(self, "_record_signal").bind(signal_order, phase))
+
+        controller.subscribe("phase_new_tile", func(): bus_order.append("phase_new_tile#a"))
+        controller.subscribe("phase_new_tile", func(): bus_order.append("phase_new_tile#b"))
+        controller.subscribe("phase_growth", func():
+                bus_order.append("phase_growth")
+                var attempt = controller.end_turn()
+                if attempt != null:
+                        reentry_guard = false
+        )
+        controller.subscribe("phase_mutation", func(): bus_order.append("phase_mutation"))
+        controller.subscribe("phase_resources", func(): bus_order.append("phase_resources"))
+        controller.subscribe("phase_decay", func(): bus_order.append("phase_decay"))
+        controller.subscribe("phase_battle", func(): bus_order.append("phase_battle"))
+        controller.subscribe("phase_review", func(): bus_order.append("phase_review"))
+
+        await _await_turn(controller)
+
+        var expected_signal := [
+                "phase_new_tile",
+                "phase_growth",
+                "phase_mutation",
+                "phase_resources",
+                "phase_decay",
+                "phase_battle",
+                "phase_review",
+        ]
+        if signal_order.size() < expected_signal.size():
+                controller.queue_free()
+                push_error("Not all phases emitted during the first turn")
+                return false
+        if signal_order.slice(0, expected_signal.size()) != expected_signal:
+                controller.queue_free()
+                push_error("Signal phase order incorrect: %s" % signal_order.slice(0, expected_signal.size()))
+                return false
+
+        var expected_bus := [
+                "phase_new_tile#a",
+                "phase_new_tile#b",
+                "phase_growth",
+                "phase_mutation",
+                "phase_resources",
+                "phase_decay",
+                "phase_battle",
+                "phase_review",
+        ]
+        if bus_order.size() < expected_bus.size():
+                controller.queue_free()
+                push_error("Bus did not fire all expected callbacks on first turn")
+                return false
+        if bus_order.slice(0, expected_bus.size()) != expected_bus:
+                controller.queue_free()
+                push_error("Bus callback order incorrect: %s" % bus_order.slice(0, expected_bus.size()))
+                return false
+
+        if not reentry_guard:
+                controller.queue_free()
+                push_error("Re-entrant end_turn call was not blocked")
+                return false
+
+        if not controller.is_in_review:
+                controller.queue_free()
+                push_error("Review gate should be active after phase_review")
+                return false
+        if controller.is_advancing:
+                controller.queue_free()
+                push_error("Controller should not be advancing while in review")
+                return false
+
+        if RunState.turn != 1:
+                controller.queue_free()
+                push_error("RunState.turn should be 1 after first turn, got %d" % RunState.turn)
+                return false
+
+        var blocked = controller.end_turn()
+        if blocked != null:
+                controller.queue_free()
+                push_error("end_turn should be ignored while review is active")
+                return false
+        if RunState.turn != 1:
+                controller.queue_free()
+                push_error("Turn count should not advance while review gate is open")
+                return false
+
+        controller.ack_review_and_resume()
+        if controller.is_in_review:
+                controller.queue_free()
+                push_error("Review flag should clear after acknowledgement")
+                return false
+
+        await _await_turn(controller)
+        var total_expected := expected_signal.size() * 2
+        if signal_order.size() != total_expected:
+                controller.queue_free()
+                push_error("Expected %d total signal emissions after two turns, got %d" % [total_expected, signal_order.size()])
+                return false
+        if signal_order.slice(expected_signal.size(), expected_signal.size() * 2) != expected_signal:
+                controller.queue_free()
+                push_error("Second turn signal order incorrect: %s" % signal_order.slice(expected_signal.size(), expected_signal.size() * 2))
+                return false
+        if bus_order.size() != expected_bus.size() * 2:
+                controller.queue_free()
+                push_error("Expected %d bus callbacks after two turns, got %d" % [expected_bus.size() * 2, bus_order.size()])
+                return false
+        if bus_order.slice(expected_bus.size(), expected_bus.size() * 2) != expected_bus:
+                controller.queue_free()
+                push_error("Second turn bus order incorrect: %s" % bus_order.slice(expected_bus.size(), expected_bus.size() * 2))
+                return false
+        if RunState.turn != 2:
+                controller.queue_free()
+                push_error("Turn counter should be 2 after two turns, got %d" % RunState.turn)
+                return false
+        if signal_order.count("phase_review") != 2:
+                controller.queue_free()
+                push_error("Phase review should fire once per turn")
+                return false
+
+        controller.ack_review_and_resume()
+        controller.queue_free()
+        return true


### PR DESCRIPTION
## Summary
- replace the turn controller with a node-driven phase bus that sequences phases, exposes subscribe/unsubscribe helpers, and gates play behind a review banner
- add the review banner UI, wire main scene systems into the new phase bus, and block placement input during reviews
- provide stubbed resource/decay/battle handlers and extend the test harness with async support plus a dedicated turn bus test

## Testing
- `godot --headless --path . --script res://tests/run_tests.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e48b24fae88322bb188c581e2416d9