### PR TITLE
Fix RunState static access

### DIFF
--- a/src/core/RunState.gd
+++ b/src/core/RunState.gd
@@ -1,28 +1,29 @@
 extends Node
+class_name RunState
 
 const Deck := preload("res://src/systems/Deck.gd")
 
-var seed:int = 0
-var turn:int = 0
-var chosen_variants:Dictionary = {}
-var deck:Array = []
-var draw_index:int = 0
-var overgrowth:Dictionary = {}
-var connected_set:Dictionary = {}
+static var seed: int = 0
+static var turn: int = 0
+static var chosen_variants: Dictionary = {}
+static var deck: Array = []
+static var draw_index: int = 0
+static var overgrowth: Dictionary = {}
+static var connected_set: Dictionary = {}
 
-func start_new_run() -> void:
-				seed = int(Time.get_unix_time_from_system())
-				Config.load_all()
-				chosen_variants = {}
-				deck = []
-				draw_index = 0
-				overgrowth = {}
-				connected_set = {}
-				turn = 0
-				finalize_after_draft()
+static func start_new_run() -> void:
+	seed = int(Time.get_unix_time_from_system())
+	Config.load_all()
+	chosen_variants = {}
+	deck = []
+	draw_index = 0
+	overgrowth = {}
+	connected_set = {}
+	turn = 0
+	RunState.finalize_after_draft()
 
-func finalize_after_draft() -> void:
-	var distribution : Dictionary = {}
+static func finalize_after_draft() -> void:
+	var distribution: Dictionary = {}
 	if Config.deck().has("distribution"):
 		distribution = Config.deck()["distribution"]
 	deck = Deck.build_deck(chosen_variants, distribution, seed)


### PR DESCRIPTION
## Summary
- register RunState as a global class and expose its state as static properties
- update run lifecycle helpers to use static functions so other systems can access RunState.turn

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e492e2e7f08322be6a0fbb171a992c