### PR TITLE
Remove duplicate RunState class name

### DIFF
--- a/src/core/RunState.gd
+++ b/src/core/RunState.gd
@@ -1,5 +1,4 @@
 extends Node
-class_name RunState
 
 const Deck := preload("res://src/systems/Deck.gd")
 


### PR DESCRIPTION
## Summary
- remove the `class_name RunState` declaration from `src/core/RunState.gd` to avoid clashing with the autoload singleton

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e49b57ca448322adce4a58d8730065