### PR TITLE
Fix HexGrid indentation to resolve parse errors

### DIFF
--- a/scripts/grid/HexGrid.gd
+++ b/scripts/grid/HexGrid.gd
@@ -22,6 +22,7 @@ var _cell_states: Dictionary[Vector2i, CellData] = {}
 var _cursor_node: HexCursor
 var _cursor_axial: Vector2i = Vector2i.ZERO
 
+
 func _ready() -> void:
 	if not _ensure_grid_config():
 		push_error("HexGrid could not load a GridConfig resource")
@@ -29,10 +30,12 @@ func _ready() -> void:
 	_generate_grid()
 	_spawn_cursor()
 
+
 func _ensure_grid_config() -> bool:
 	if grid_config:
 		return true
 	return false
+
 
 func _generate_grid() -> void:
 	for child in get_children():
@@ -45,19 +48,19 @@ func _generate_grid() -> void:
 	if not _ensure_grid_config():
 		return
 
-        var radius: int = grid_config.radius
+	var radius: int = grid_config.radius
 	for q in range(-radius, radius + 1):
 		for r in range(-radius, radius + 1):
 			if abs(q + r) > radius:
 				continue
-                        var axial: Vector2i = Vector2i(q, r)
+			var axial: Vector2i = Vector2i(q, r)
 			var cell: HexCell = cell_scene.instantiate()
 			add_child(cell)
 			cell.position = Coord.axial_to_world(axial, grid_config.cell_size)
-                        var cell_type: int = CellType.Type.EMPTY
+			var cell_type: int = CellType.Type.EMPTY
 			if axial == Vector2i.ZERO:
 				cell_type = CellType.Type.TOTEM
-                        var color: Color = grid_config.get_color(cell_type)
+			var color: Color = grid_config.get_color(cell_type)
 			cell.configure(axial, grid_config.cell_size, grid_config.selection_color, color)
 			cells[axial] = cell
 
@@ -66,6 +69,7 @@ func _generate_grid() -> void:
 			if cell_type == CellType.Type.TOTEM:
 				data.variant_id = "totem_default"
 			_cell_states[axial] = data
+
 
 func _spawn_cursor() -> void:
 	if _cursor_node:
@@ -78,30 +82,36 @@ func _spawn_cursor() -> void:
 	_cursor_axial = Vector2i.ZERO
 	_update_cursor_position()
 
+
 func move_cursor(delta: Vector2i) -> void:
-        var target: Vector2i = _cursor_axial + delta
+	var target: Vector2i = _cursor_axial + delta
 	if not is_within_grid(target):
 		return
 	_cursor_axial = target
 	_update_cursor_position()
 
+
 func get_cursor_axial() -> Vector2i:
 	return _cursor_axial
+
 
 func axial_to_world(axial: Vector2i) -> Vector2:
 	if not _ensure_grid_config():
 		return Vector2.ZERO
 	return Coord.axial_to_world(axial, grid_config.cell_size)
 
+
 func world_to_axial(position: Vector2) -> Vector2i:
 	if not _ensure_grid_config():
 		return Vector2i.ZERO
 	return Coord.world_to_axial(position, grid_config.cell_size)
 
+
 func is_within_grid(axial: Vector2i) -> bool:
 	if not _ensure_grid_config():
 		return false
 	return Coord.axial_distance(Vector2i.ZERO, axial) <= grid_config.radius
+
 
 func get_cell_type_at(axial: Vector2i) -> int:
 	var data: CellData = _cell_states.get(axial)
@@ -109,8 +119,10 @@ func get_cell_type_at(axial: Vector2i) -> int:
 		return data.cell_type
 	return CellType.Type.EMPTY
 
+
 func get_cell_data(axial: Vector2i) -> CellData:
 	return _cell_states.get(axial)
+
 
 func get_neighbors(axial: Vector2i) -> Array[Vector2i]:
 	var result: Array[Vector2i] = []
@@ -120,6 +132,7 @@ func get_neighbors(axial: Vector2i) -> Array[Vector2i]:
 			result.append(neighbor)
 	return result
 
+
 func get_cells_of_type(cell_type: int) -> Array[Vector2i]:
 	var positions: Array[Vector2i] = []
 	for axial in _cell_states.keys():
@@ -128,22 +141,26 @@ func get_cells_of_type(cell_type: int) -> Array[Vector2i]:
 			positions.append(axial)
 	return positions
 
+
 func count_neighbors_of_type(axial: Vector2i, cell_type: int) -> int:
-        var count: int = 0
+	var count: int = 0
 	for neighbor: Vector2i in get_neighbors(axial):
 		if get_cell_type_at(neighbor) == cell_type:
 			count += 1
 	return count
+
 
 func highlight_cell(axial: Vector2i, selected: bool) -> void:
 	var cell: HexCell = cells.get(axial)
 	if cell:
 		cell.set_selected(selected)
 
+
 func clear_all_highlights() -> void:
 	for cell in cells.values():
 		if cell is HexCell:
 			(cell as HexCell).set_selected(false)
+
 
 func try_place_tile(axial: Vector2i, cell_type: int, variant_id: String = "") -> bool:
 	if not _cell_states.has(axial):
@@ -163,7 +180,7 @@ func try_place_tile(axial: Vector2i, cell_type: int, variant_id: String = "") ->
 		_log_build_failure("Placement blocked: tiles must connect to the forest network.")
 		return false
 
-        var color: Color = grid_config.get_color(cell_type)
+	var color: Color = grid_config.get_color(cell_type)
 	data.set_type(cell_type, color)
 	data.variant_id = variant_id
 	data.sprout_capacity = 0
@@ -180,6 +197,7 @@ func try_place_tile(axial: Vector2i, cell_type: int, variant_id: String = "") ->
 	emit_signal("tile_placed", axial, cell_type)
 	return true
 
+
 func process_turn() -> Dictionary:
 	var matured: Array[Vector2i] = _advance_overgrowth()
 	if not matured.is_empty():
@@ -188,11 +206,13 @@ func process_turn() -> Dictionary:
 		"groves_bloomed": matured,
 	}
 
+
 func get_total_sprouts() -> int:
-        var total: int = 0
+	var total: int = 0
 	for data: CellData in _cell_states.values():
 		total += data.sprout_count
 	return total
+
 
 func collect_clusters(cell_type: int) -> Array:
 	var clusters: Array = []
@@ -220,10 +240,12 @@ func collect_clusters(cell_type: int) -> Array:
 			clusters.append(cluster)
 	return clusters
 
+
 func _update_cursor_position() -> void:
 	if not _cursor_node:
 		return
 	_cursor_node.position = axial_to_world(_cursor_axial)
+
 
 func _is_connected_to_network(axial: Vector2i) -> bool:
 	for neighbor: Vector2i in get_neighbors(axial):
@@ -231,6 +253,7 @@ func _is_connected_to_network(axial: Vector2i) -> bool:
 		if CellType.is_network_member(neighbor_type):
 			return true
 	return false
+
 
 func _recompute_overgrowth() -> void:
 	var empty_cells: Array[Vector2i] = []
@@ -280,6 +303,7 @@ func _recompute_overgrowth() -> void:
 	if not newly_overgrown.is_empty():
 		emit_signal("overgrowth_created", newly_overgrown)
 
+
 func _convert_to_overgrowth(axial: Vector2i, data: CellData) -> void:
 	data.cell_type = CellType.Type.OVERGROWTH
 	data.color = grid_config.get_color(CellType.Type.OVERGROWTH)
@@ -291,6 +315,7 @@ func _convert_to_overgrowth(axial: Vector2i, data: CellData) -> void:
 		cell.set_sprout_count(0)
 		cell.show_grove_badge(false)
 		cell.set_growth_progress(0, data.growth_duration, true)
+
 
 func _advance_overgrowth() -> Array[Vector2i]:
 	var matured: Array[Vector2i] = []
@@ -304,7 +329,7 @@ func _advance_overgrowth() -> Array[Vector2i]:
 			data.growth_timer = grid_config.overgrowth_maturation_turns
 		else:
 			data.growth_timer = max(0, data.growth_timer - 1)
-                var elapsed: int = data.growth_duration - data.growth_timer
+		var elapsed: int = data.growth_duration - data.growth_timer
 		var cell: HexCell = cells.get(axial)
 		if cell:
 			cell.set_growth_progress(elapsed, data.growth_duration, true)
@@ -323,10 +348,12 @@ func _advance_overgrowth() -> Array[Vector2i]:
 				cell.flash()
 	return matured
 
+
 func _is_boundary(axial: Vector2i) -> bool:
 	if not is_within_grid(axial):
 		return true
 	return Coord.axial_distance(Vector2i.ZERO, axial) == grid_config.radius
+
 
 func _log_build_failure(message: String) -> void:
 	push_warning("[Grid] %s" % message)


### PR DESCRIPTION
## Summary
- normalize indentation in `scripts/grid/HexGrid.gd` to eliminate mixed tab/space parsing issues

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4f04d76448322945e24dc1899292d