### PR TITLE
Add buildable tile overlays to hex grid

### DIFF
--- a/scenes/HexCell.tscn
+++ b/scenes/HexCell.tscn
@@ -8,15 +8,20 @@ script = ExtResource("1_9ocxy")
 [node name="Polygon2D" type="Polygon2D" parent="."]
 color = Color(0.952941, 0.905882, 0.780392, 1)
 
-[node name="GrowthBadge" type="Polygon2D" parent="."]
+[node name="BuildableOverlay" type="Polygon2D" parent="."]
 visible = false
 z_index = 1
+color = Color(0.8, 0.8, 0.8, 0.35)
+
+[node name="GrowthBadge" type="Polygon2D" parent="."]
+visible = false
+z_index = 2
 color = Color(0.972549, 0.87451, 0.321569, 1)
 
 [node name="SproutLabel" type="Label" parent="."]
 visible = false
 modulate = Color(0.964706, 0.996078, 0.960784, 1)
-z_index = 2
+z_index = 3
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5

--- a/scripts/core/RunState.gd
+++ b/scripts/core/RunState.gd
@@ -56,9 +56,10 @@ func _ready() -> void:
 	_tile_definitions = _load_tile_definitions()
 	_build_initial_deck()
 	_reset_resources()
-	_apply_tile_descriptions()
-	_refresh_palette_options()
-	_update_info_panel()
+        _apply_tile_descriptions()
+        _refresh_palette_options()
+        _update_info_panel()
+        _update_buildable_highlights()
 
 func try_place_tile(axial: Vector2i, cell_type: int = CellType.Type.EMPTY) -> bool:
 		if is_deck_empty():
@@ -84,9 +85,10 @@ func try_place_tile(axial: Vector2i, cell_type: int = CellType.Type.EMPTY) -> bo
 		_turn += 1
 		_hex_grid.process_turn()
 		_recalculate_resources()
-		_refresh_palette_options()
-		_update_info_panel()
-		return true
+                _refresh_palette_options()
+                _update_info_panel()
+                _update_buildable_highlights()
+                return true
 
 func is_deck_empty() -> bool:
 		return _deck_queue.is_empty()
@@ -252,12 +254,17 @@ func _refresh_palette_options() -> void:
 	_palette_state.set_options(available, counts)
 
 func _update_info_panel() -> void:
-		if _info_panel:
-				_info_panel.update_turn(_turn)
-				_info_panel.update_deck(_get_total_deck_count(), _deck_counts)
-				_info_panel.update_resources(_resources, _resource_generation)
-				_info_panel.update_sprouts(_hex_grid.get_total_sprouts())
-				_info_panel.update_next_tile(peek_next_tile_type())
+                if _info_panel:
+                                _info_panel.update_turn(_turn)
+                                _info_panel.update_deck(_get_total_deck_count(), _deck_counts)
+                                _info_panel.update_resources(_resources, _resource_generation)
+                                _info_panel.update_sprouts(_hex_grid.get_total_sprouts())
+                                _info_panel.update_next_tile(peek_next_tile_type())
+
+func _update_buildable_highlights() -> void:
+        if not _hex_grid:
+                return
+        _hex_grid.update_buildable_highlights(peek_next_tile_type())
 
 func _get_variant_id(cell_type: int) -> String:
 	var key := CellType.to_key(cell_type)

--- a/scripts/grid/HexCell.gd
+++ b/scripts/grid/HexCell.gd
@@ -5,6 +5,7 @@ extends Node2D
 class_name HexCell
 
 @onready var polygon: Polygon2D = $Polygon2D
+@onready var buildable_overlay: Polygon2D = $BuildableOverlay
 @onready var growth_badge: Polygon2D = $GrowthBadge
 @onready var sprout_label: Label = $SproutLabel
 
@@ -12,6 +13,7 @@ var axial: Vector2i = Vector2i.ZERO
 var _cell_size: float = 52.0
 var _cell_color: Color = Color.WHITE
 var _selection_color: Color = Color.DARK_GREEN
+var _buildable_color: Color = Color(0.8, 0.8, 0.8, 0.35)
 var _is_selected := false
 var _flash_tween: Tween
 
@@ -24,10 +26,13 @@ func configure(axial_coord: Vector2i, cell_size: float, selection_color: Color, 
 	_cell_size = cell_size
 	_selection_color = selection_color
 	_cell_color = initial_color
-	polygon.polygon = _build_polygon_points(cell_size)
-	polygon.modulate = Color.WHITE
-	growth_badge.polygon = _build_polygon_points(cell_size * 0.35)
-	growth_badge.visible = false
+        polygon.polygon = _build_polygon_points(cell_size)
+        polygon.modulate = Color.WHITE
+        buildable_overlay.polygon = _build_polygon_points(cell_size)
+        buildable_overlay.visible = false
+        buildable_overlay.color = _buildable_color
+        growth_badge.polygon = _build_polygon_points(cell_size * 0.35)
+        growth_badge.visible = false
 	sprout_label.text = ""
 	sprout_label.visible = false
 	_show_growth_progress = false
@@ -46,12 +51,18 @@ func is_selected() -> bool:
 	return _is_selected
 
 func set_cell_color(color: Color) -> void:
-	_cell_color = color
-	_apply_color()
+        _cell_color = color
+        _apply_color()
+
+func set_buildable_highlight(active: bool, color: Color) -> void:
+        _buildable_color = color
+        if buildable_overlay:
+                buildable_overlay.color = _buildable_color
+                buildable_overlay.visible = active
 
 func flash(duration: float = 0.2) -> void:
-	if _flash_tween:
-		_flash_tween.kill()
+        if _flash_tween:
+                _flash_tween.kill()
 	polygon.modulate = Color(1.4, 1.4, 1.4, 1.0)
 	_flash_tween = create_tween()
 	_flash_tween.tween_property(polygon, "modulate", Color.WHITE, duration)

--- a/scripts/grid/HexGrid.gd
+++ b/scripts/grid/HexGrid.gd
@@ -60,9 +60,10 @@ func _generate_grid() -> void:
 			var cell_type: int = CellType.Type.EMPTY
 			if axial == Vector2i.ZERO:
 				cell_type = CellType.Type.TOTEM
-			var color: Color = grid_config.get_color(cell_type)
-			cell.configure(axial, grid_config.cell_size, grid_config.selection_color, color)
-			cells[axial] = cell
+                        var color: Color = grid_config.get_color(cell_type)
+                        cell.configure(axial, grid_config.cell_size, grid_config.selection_color, color)
+                        cell.set_buildable_highlight(false, grid_config.buildable_highlight_color)
+                        cells[axial] = cell
 
 			var data: CellData = CellData.new()
 			data.set_type(cell_type, color)
@@ -151,36 +152,66 @@ func count_neighbors_of_type(axial: Vector2i, cell_type: int) -> int:
 
 
 func highlight_cell(axial: Vector2i, selected: bool) -> void:
-	var cell: HexCell = cells.get(axial)
-	if cell:
-		cell.set_selected(selected)
+        var cell: HexCell = cells.get(axial)
+        if cell:
+                cell.set_selected(selected)
 
 
 func clear_all_highlights() -> void:
-	for cell in cells.values():
-		if cell is HexCell:
-			(cell as HexCell).set_selected(false)
+        for cell in cells.values():
+                if cell is HexCell:
+                        (cell as HexCell).set_selected(false)
+
+
+func update_buildable_highlights(cell_type: int) -> void:
+        if not _ensure_grid_config():
+                return
+        var highlight_color: Color = grid_config.buildable_highlight_color
+        var allow_highlight := CellType.is_placeable(cell_type)
+        for axial in _cell_states.keys():
+                var cell: HexCell = cells.get(axial)
+                if not cell:
+                        continue
+                var active := allow_highlight and can_place_tile(axial, cell_type)
+                cell.set_buildable_highlight(active, highlight_color)
+
+
+func can_place_tile(axial: Vector2i, cell_type: int) -> bool:
+        if not _ensure_grid_config():
+                return false
+        if not _cell_states.has(axial):
+                return false
+        if not CellType.is_placeable(cell_type):
+                return false
+        var data: CellData = _cell_states[axial]
+        if data.cell_type == CellType.Type.TOTEM:
+                return false
+        if data.cell_type != CellType.Type.EMPTY:
+                return false
+        if not grid_config.allow_isolated_builds and not _is_connected_to_network(axial):
+                return false
+        return true
 
 
 func try_place_tile(axial: Vector2i, cell_type: int, variant_id: String = "") -> bool:
-	if not _cell_states.has(axial):
-		_log_build_failure("Cannot build outside the grid.")
-		return false
-	if not CellType.is_placeable(cell_type):
-		_log_build_failure("That tile type cannot be constructed.")
-		return false
-	var data: CellData = _cell_states[axial]
-	if data.cell_type == CellType.Type.TOTEM:
-		_log_build_failure("The totem cannot be replaced.")
-		return false
-	if data.cell_type != CellType.Type.EMPTY:
-		_log_build_failure("This cell is already occupied.")
-		return false
-	if not grid_config.allow_isolated_builds and not _is_connected_to_network(axial):
-		_log_build_failure("Placement blocked: tiles must connect to the forest network.")
-		return false
+        if not _cell_states.has(axial):
+                _log_build_failure("Cannot build outside the grid.")
+                return false
+        if not CellType.is_placeable(cell_type):
+                _log_build_failure("That tile type cannot be constructed.")
+                return false
+        var data: CellData = _cell_states[axial]
+        if data.cell_type == CellType.Type.TOTEM:
+                _log_build_failure("The totem cannot be replaced.")
+                return false
+        if data.cell_type != CellType.Type.EMPTY:
+                _log_build_failure("This cell is already occupied.")
+                return false
+        if not grid_config.allow_isolated_builds and not _is_connected_to_network(axial):
+                _log_build_failure("Placement blocked: tiles must connect to the forest network.")
+                return false
 
-	var color: Color = grid_config.get_color(cell_type)
+        var color: Color = grid_config.get_color(cell_type)
 	data.set_type(cell_type, color)
 	data.variant_id = variant_id
 	data.sprout_capacity = 0


### PR DESCRIPTION
## Summary
- add a buildable overlay polygon to each hex cell to support placement indicators
- compute and update buildable highlights for the current tile queue on the grid
- refresh placement indicators whenever the deck state changes during a run

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4ffcf438c8322829ed9e3e851c4b1