### PR TITLE
Fix HexCell indentation to restore Godot parsing

### DIFF
--- a/scripts/grid/HexCell.gd
+++ b/scripts/grid/HexCell.gd
@@ -26,13 +26,13 @@ func configure(axial_coord: Vector2i, cell_size: float, selection_color: Color, 
 	_cell_size = cell_size
 	_selection_color = selection_color
 	_cell_color = initial_color
-        polygon.polygon = _build_polygon_points(cell_size)
-        polygon.modulate = Color.WHITE
-        buildable_overlay.polygon = _build_polygon_points(cell_size)
-        buildable_overlay.visible = false
-        buildable_overlay.color = _buildable_color
-        growth_badge.polygon = _build_polygon_points(cell_size * 0.35)
-        growth_badge.visible = false
+	polygon.polygon = _build_polygon_points(cell_size)
+	polygon.modulate = Color.WHITE
+	buildable_overlay.polygon = _build_polygon_points(cell_size)
+	buildable_overlay.visible = false
+	buildable_overlay.color = _buildable_color
+	growth_badge.polygon = _build_polygon_points(cell_size * 0.35)
+	growth_badge.visible = false
 	sprout_label.text = ""
 	sprout_label.visible = false
 	_show_growth_progress = false
@@ -51,18 +51,18 @@ func is_selected() -> bool:
 	return _is_selected
 
 func set_cell_color(color: Color) -> void:
-        _cell_color = color
-        _apply_color()
+	_cell_color = color
+	_apply_color()
 
 func set_buildable_highlight(active: bool, color: Color) -> void:
-        _buildable_color = color
-        if buildable_overlay:
-                buildable_overlay.color = _buildable_color
-                buildable_overlay.visible = active
+	_buildable_color = color
+	if buildable_overlay:
+		buildable_overlay.color = _buildable_color
+		buildable_overlay.visible = active
 
 func flash(duration: float = 0.2) -> void:
-        if _flash_tween:
-                _flash_tween.kill()
+	if _flash_tween:
+		_flash_tween.kill()
 	polygon.modulate = Color(1.4, 1.4, 1.4, 1.0)
 	_flash_tween = create_tween()
 	_flash_tween.tween_property(polygon, "modulate", Color.WHITE, duration)


### PR DESCRIPTION
## Summary
- convert HexCell.gd indentation to tabs to follow the project's formatting
- resolve Godot's parsing errors so the HexCell global class loads correctly

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e503237b9c83228f5af6aa244d3cfa