### PR TITLE
Remove conflicting RunState class_name

### DIFF
--- a/scripts/core/RunState.gd
+++ b/scripts/core/RunState.gd
@@ -1,4 +1,3 @@
-class_name RunState
 extends Node
 ## Coordinates deck management, turn resolution, and resource tracking for a run.
 


### PR DESCRIPTION
## Summary
- remove the class_name declaration from the RunState scene script to avoid shadowing the autoload singleton

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e505d20bd08322909a1b59bd9da760