### PR TITLE
Fix RunState typing conflict in InputController

### DIFF
--- a/scripts/input/InputController.gd
+++ b/scripts/input/InputController.gd
@@ -6,11 +6,10 @@ extends Node
 @export var turn_controller_path: NodePath
 
 const HexGrid := preload("res://scripts/grid/HexGrid.gd")
-const RunState := preload("res://scripts/core/RunState.gd")
 const TurnController := preload("res://src/systems/TurnController.gd")
 
 var _hex_grid: HexGrid
-var _run_state: RunState
+var _run_state
 var _turn_controller: TurnController
 
 const MOVE_VECTORS := {


### PR DESCRIPTION
## Summary
- remove the unused RunState preload in InputController to avoid clashing with the RunState autoload
- relax the _run_state variable typing so it can accept the scene's RunState node

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e506e2a7208322a7c32f560782071f