### PR TITLE
Fix Godot script typing and formatting issues

### DIFF
--- a/src/core/PathHex.gd
+++ b/src/core/PathHex.gd
@@ -15,83 +15,83 @@ const DIRECTIONS := [
 static var _board: Node = null
 
 static func set_board(board: Node) -> void:
-	_board = board
+    _board = board
 
 static func bfs_first_step(from_ax: Vector2i, is_goal: Callable, is_walkable: Callable) -> Variant:
-		var visited := {}
-		var parents := {}
-		var queue: Array = []
-		queue.append(from_ax)
-		visited[_key(from_ax)] = true
-		while queue.size() > 0:
-				var current: Vector2i = queue.pop_front()
-				if is_goal.call([current]):
-						var step := _retrace_first_step(from_ax, current, parents)
-						if step != null:
-								return step
-				for dir in DIRECTIONS:
-						var nxt := current + dir
-						var nxt_key := _key(nxt)
-			if visited.has(nxt_key):
-				continue
-			if not is_walkable.call([nxt]):
-				continue
-			visited[nxt_key] = true
-			parents[nxt_key] = current
-			queue.append(nxt)
-	return null
+    var visited := {}
+    var parents := {}
+    var queue: Array[Vector2i] = []
+    queue.append(from_ax)
+    visited[_key(from_ax)] = true
+    while queue.size() > 0:
+        var current: Vector2i = queue.pop_front()
+        if is_goal.call([current]):
+            var step := _retrace_first_step(from_ax, current, parents)
+            if step != null:
+                return step
+        for dir in DIRECTIONS:
+            var nxt := current + dir
+            var nxt_key := _key(nxt)
+            if visited.has(nxt_key):
+                continue
+            if not is_walkable.call([nxt]):
+                continue
+            visited[nxt_key] = true
+            parents[nxt_key] = current
+            queue.append(nxt)
+    return null
 
 static func nearest_connected_step(from_ax: Vector2i) -> Variant:
-	if _board == null:
-		return null
-	if not _board.has_method("is_empty") or not _board.has_method("is_decay"):
-		return null
-	var goal := func (ax: Vector2i) -> bool:
-		for dir in DIRECTIONS:
-			var neighbor := ax + dir
-			if RunState.connected_set.has(_key(neighbor)):
-				return true
-		return false
-	var walkable := func (ax: Vector2i) -> bool:
-		var k := _key(ax)
-		if RunState.connected_set.has(k):
-			return false
-		if _board.is_decay(ax):
-			return true
-		return _board.is_empty(ax)
-	return bfs_first_step(from_ax, goal, walkable)
+    if _board == null:
+        return null
+    if not _board.has_method("is_empty") or not _board.has_method("is_decay"):
+        return null
+    var goal := func (ax: Vector2i) -> bool:
+        for dir in DIRECTIONS:
+            var neighbor := ax + dir
+            if RunState.connected_set.has(_key(neighbor)):
+                return true
+        return false
+    var walkable := func (ax: Vector2i) -> bool:
+        var k := _key(ax)
+        if RunState.connected_set.has(k):
+            return false
+        if _board.is_decay(ax):
+            return true
+        return _board.is_empty(ax)
+    return bfs_first_step(from_ax, goal, walkable)
 
 static func _key(ax: Vector2i) -> String:
-	return "%d,%d" % [ax.x, ax.y]
+    return "%d,%d" % [ax.x, ax.y]
 
 static func _retrace_first_step(start_ax: Vector2i, goal_ax: Vector2i, parents: Dictionary) -> Variant:
-		var path: Array = []
-		var current := goal_ax
-		var current_key := _key(current)
-		path.push_front(current)
-		while parents.has(current_key):
-				var prev: Vector2i = parents[current_key]
-				path.push_front(prev)
-				current = prev
-				current_key = _key(current)
-		if path.is_empty():
-				return null
-		if path[0] != start_ax:
-				path.push_front(start_ax)
-		return _first_non_decay_step(path)
+    var path: Array = []
+    var current := goal_ax
+    var current_key := _key(current)
+    path.push_front(current)
+    while parents.has(current_key):
+        var prev: Vector2i = parents[current_key]
+        path.push_front(prev)
+        current = prev
+        current_key = _key(current)
+    if path.is_empty():
+        return null
+    if path[0] != start_ax:
+        path.push_front(start_ax)
+    return _first_non_decay_step(path)
 
 static func _first_non_decay_step(path: Array) -> Variant:
-		if path.size() <= 1:
-				return null
-		for i in range(1, path.size()):
-				var step: Variant = path[i]
-				if typeof(step) != TYPE_VECTOR2I:
-						continue
-				var step_ax: Vector2i = step
-				if _board == null:
-						return step_ax
-				if not _board.has_method("is_decay"):
-						return step_ax
-				if not _board.is_decay(step_ax):
-						return step_ax
-		return null
+    if path.size() <= 1:
+        return null
+    for i in range(1, path.size()):
+        var step: Variant = path[i]
+        if typeof(step) != TYPE_VECTOR2I:
+            continue
+        var step_ax: Vector2i = step
+        if _board == null:
+            return step_ax
+        if not _board.has_method("is_decay"):
+            return step_ax
+        if not _board.is_decay(step_ax):
+            return step_ax
+    return null

--- a/src/data/Config.gd
+++ b/src/data/Config.gd
@@ -1,149 +1,151 @@
 extends Node
+class_name Config
 
-var _tiles := {}
-var _deck := {}
-var _totems := {}
-var _sprouts := {}
-var _decay := {}
+static var _tiles: Dictionary = {}
+static var _deck: Dictionary = {}
+static var _totems: Dictionary = {}
+static var _sprouts: Dictionary = {}
+static var _decay: Dictionary = {}
 
-func load_all() -> void:
-	_tiles = _load_json("res://data/tiles.json")
-	_deck = _load_json("res://data/deck.json")
-	_totems = _load_json("res://data/totems.json")
-	_sprouts = _load_json("res://data/sprouts.json")
-	_decay = _load_json("res://data/decay.json")
-	if not _validate_tiles(_tiles):
-		_tiles = {}
-	if not _validate_deck(_deck):
-		_deck = {}
+static func load_all() -> void:
+    _tiles = _load_json("res://data/tiles.json")
+    _deck = _load_json("res://data/deck.json")
+    _totems = _load_json("res://data/totems.json")
+    _sprouts = _load_json("res://data/sprouts.json")
+    _decay = _load_json("res://data/decay.json")
+    if not _validate_tiles(_tiles):
+        _tiles = {}
+    if not _validate_deck(_deck):
+        _deck = {}
 
-func tiles() -> Dictionary:
-	return _tiles
+static func tiles() -> Dictionary:
+    return _tiles
 
-func deck() -> Dictionary:
-	return _deck
+static func deck() -> Dictionary:
+    return _deck
 
-func totems() -> Dictionary:
-	return _totems
+static func totems() -> Dictionary:
+    return _totems
 
-func sprouts() -> Dictionary:
-	return _sprouts
+static func sprouts() -> Dictionary:
+    return _sprouts
 
-func decay() -> Dictionary:
-	return _decay
+static func decay() -> Dictionary:
+    return _decay
 
-func get_variant(category:String, id:String) -> Dictionary:
-	if not _tiles.has("variants"):
-		return {}
-	var variants_data: Variant = _tiles.get("variants")
-	if typeof(variants_data) != TYPE_DICTIONARY:
-		return {}
-	var variants: Dictionary = variants_data
-	if not variants.has(category):
-		return {}
-	var category_variants_data: Variant = variants.get(category)
-	if typeof(category_variants_data) != TYPE_ARRAY:
-		return {}
-	for v_variant in category_variants_data:
-		if typeof(v_variant) == TYPE_DICTIONARY:
-			var v: Dictionary = v_variant
-			if v.get("id", "") == id:
-				return v
-	return {}
+static func get_variant(category: String, id: String) -> Dictionary:
+    if not _tiles.has("variants"):
+        return {}
+    var variants_data: Variant = _tiles.get("variants")
+    if typeof(variants_data) != TYPE_DICTIONARY:
+        return {}
+    var variants: Dictionary = variants_data
+    if not variants.has(category):
+        return {}
+    var category_variants_data: Variant = variants.get(category)
+    if typeof(category_variants_data) != TYPE_ARRAY:
+        return {}
+    for v_variant in category_variants_data:
+        if typeof(v_variant) == TYPE_DICTIONARY:
+            var v: Dictionary = v_variant
+            if v.get("id", "") == id:
+                return v
+    return {}
 
-func _load_json(path:String) -> Dictionary:
-	if not FileAccess.file_exists(path):
-		push_error("Missing JSON: %s" % path)
-		return {}
-	var f := FileAccess.open(path, FileAccess.READ)
-	if f == null:
-		push_error("Unable to open JSON: %s" % path)
-		return {}
-	var text := f.get_as_text()
-	var data: Variant = JSON.parse_string(text)
-	if typeof(data) != TYPE_DICTIONARY:
-		push_error("Invalid JSON: %s" % path)
-		return {}
-	return data
+static func _load_json(path: String) -> Dictionary:
+    if not FileAccess.file_exists(path):
+        push_error("Missing JSON: %s" % path)
+        return {}
+    var f := FileAccess.open(path, FileAccess.READ)
+    if f == null:
+        push_error("Unable to open JSON: %s" % path)
+        return {}
+    var text := f.get_as_text()
+    var data: Variant = JSON.parse_string(text)
+    if typeof(data) != TYPE_DICTIONARY:
+        push_error("Invalid JSON: %s" % path)
+        return {}
+    return data
 
-func _validate_tiles(t:Dictionary) -> bool:
-	if t.is_empty():
-		_fatal_config("tiles.json missing or empty")
-		return false
-	if not t.has("categories") or not t.has("variants"):
-		_fatal_config("tiles.json missing keys")
-		return false
-	var categories_data: Variant = t.get("categories")
-	if typeof(categories_data) != TYPE_ARRAY:
-		_fatal_config("tiles.json categories must be an array")
-		return false
-	var categories: Array = categories_data
-	for c in categories:
-		if typeof(c) != TYPE_STRING:
-			_fatal_config("tiles.json categories must be strings")
-			return false
-	var variants_data: Variant = t.get("variants")
-	if typeof(variants_data) != TYPE_DICTIONARY:
-		_fatal_config("tiles.json variants must be a dictionary")
-		return false
-	var variants: Dictionary = variants_data
-	for category in categories:
-		if not variants.has(category):
-			_fatal_config("tiles.json missing variants for %s" % category)
-			return false
-		var entries_data: Variant = variants.get(category)
-		if typeof(entries_data) != TYPE_ARRAY:
-			_fatal_config("tiles.json variants for %s must be an array" % category)
-			return false
-		var entries: Array = entries_data
-		for entry_variant in entries:
-			if typeof(entry_variant) != TYPE_DICTIONARY:
-				_fatal_config("tiles.json variant entries must be dictionaries")
-				return false
-			var entry: Dictionary = entry_variant
-			var vid_variant: Variant = entry.get("id", "")
-			if typeof(vid_variant) != TYPE_STRING:
-				_fatal_config("tiles.json variant id missing for %s" % category)
-				return false
-			var vid: String = vid_variant
-			if vid.is_empty():
-				_fatal_config("tiles.json variant id missing for %s" % category)
-				return false
-			if not entry.has("effects") or typeof(entry["effects"]) != TYPE_DICTIONARY:
-				_fatal_config("tiles.json variant %s missing effects" % vid)
-				return false
-	return true
+static func _validate_tiles(t: Dictionary) -> bool:
+    if t.is_empty():
+        _fatal_config("tiles.json missing or empty")
+        return false
+    if not t.has("categories") or not t.has("variants"):
+        _fatal_config("tiles.json missing keys")
+        return false
+    var categories_data: Variant = t.get("categories")
+    if typeof(categories_data) != TYPE_ARRAY:
+        _fatal_config("tiles.json categories must be an array")
+        return false
+    var categories: Array = categories_data
+    for c in categories:
+        if typeof(c) != TYPE_STRING:
+            _fatal_config("tiles.json categories must be strings")
+            return false
+    var variants_data: Variant = t.get("variants")
+    if typeof(variants_data) != TYPE_DICTIONARY:
+        _fatal_config("tiles.json variants must be a dictionary")
+        return false
+    var variants: Dictionary = variants_data
+    for category in categories:
+        if not variants.has(category):
+            _fatal_config("tiles.json missing variants for %s" % category)
+            return false
+        var entries_data: Variant = variants.get(category)
+        if typeof(entries_data) != TYPE_ARRAY:
+            _fatal_config("tiles.json variants for %s must be an array" % category)
+            return false
+        var entries: Array = entries_data
+        for entry_variant in entries:
+            if typeof(entry_variant) != TYPE_DICTIONARY:
+                _fatal_config("tiles.json variant entries must be dictionaries")
+                return false
+            var entry: Dictionary = entry_variant
+            var vid_variant: Variant = entry.get("id", "")
+            if typeof(vid_variant) != TYPE_STRING:
+                _fatal_config("tiles.json variant id missing for %s" % category)
+                return false
+            var vid: String = vid_variant
+            if vid.is_empty():
+                _fatal_config("tiles.json variant id missing for %s" % category)
+                return false
+            if not entry.has("effects") or typeof(entry["effects"]) != TYPE_DICTIONARY:
+                _fatal_config("tiles.json variant %s missing effects" % vid)
+                return false
+    return true
 
-func _validate_deck(d:Dictionary) -> bool:
-	if d.is_empty():
-		_fatal_config("deck.json missing or empty")
-		return false
-	if not d.has("distribution"):
-		_fatal_config("deck.json missing distribution")
-		return false
-	var distribution_data: Variant = d.get("distribution")
-	if typeof(distribution_data) != TYPE_DICTIONARY:
-		_fatal_config("deck.json distribution must be a dictionary")
-		return false
-	var distribution: Dictionary = distribution_data
-	for k in distribution.keys():
-		var count_variant: Variant = distribution.get(k)
-		if typeof(count_variant) != TYPE_INT:
-			_fatal_config("deck.json distribution values must be int")
-			return false
-	return true
+static func _validate_deck(d: Dictionary) -> bool:
+    if d.is_empty():
+        _fatal_config("deck.json missing or empty")
+        return false
+    if not d.has("distribution"):
+        _fatal_config("deck.json missing distribution")
+        return false
+    var distribution_data: Variant = d.get("distribution")
+    if typeof(distribution_data) != TYPE_DICTIONARY:
+        _fatal_config("deck.json distribution must be a dictionary")
+        return false
+    var distribution: Dictionary = distribution_data
+    for k in distribution.keys():
+        var count_variant: Variant = distribution.get(k)
+        if typeof(count_variant) != TYPE_INT:
+            _fatal_config("deck.json distribution values must be int")
+            return false
+    return true
 
-func _fatal_config(msg:String) -> void:
-	push_error(msg)
-	var tree: SceneTree = get_tree()
-	if tree == null:
-		return
-	var error_scene := "res://scenes/ui/ErrorPanel.tscn"
-	if ResourceLoader.exists(error_scene):
-		tree.change_scene_to_file(error_scene)
-		return
-	var main_scene_variant: Variant = ProjectSettings.get_setting("application/run/main_scene", "")
-	if typeof(main_scene_variant) == TYPE_STRING:
-		var main_scene: String = main_scene_variant
-		if main_scene != "":
-			tree.change_scene_to_file(main_scene)
+static func _fatal_config(msg: String) -> void:
+    push_error(msg)
+    var loop := Engine.get_main_loop()
+    if not (loop is SceneTree):
+        return
+    var tree: SceneTree = loop
+    var error_scene := "res://scenes/ui/ErrorPanel.tscn"
+    if ResourceLoader.exists(error_scene):
+        tree.change_scene_to_file(error_scene)
+        return
+    var main_scene_variant: Variant = ProjectSettings.get_setting("application/run/main_scene", "")
+    if typeof(main_scene_variant) == TYPE_STRING:
+        var main_scene: String = main_scene_variant
+        if main_scene != "":
+            tree.change_scene_to_file(main_scene)

--- a/src/systems/Clusters.gd
+++ b/src/systems/Clusters.gd
@@ -3,7 +3,7 @@ extends Node
 class_name Clusters
 
 static func neighbors(ax: Vector2i) -> Array:
-        var dirs := [
+        var dirs: Array[Vector2i] = [
                 Vector2i(+1, 0),
                 Vector2i(+1, -1),
                 Vector2i(0, -1),

--- a/src/systems/Decay.gd
+++ b/src/systems/Decay.gd
@@ -7,162 +7,162 @@ const Board := preload("res://src/systems/Board.gd")
 const PathHex := preload("res://src/core/PathHex.gd")
 
 const DIRECTIONS := [
-	Vector2i(1, 0),
-	Vector2i(1, -1),
-	Vector2i(0, -1),
-	Vector2i(-1, 0),
-	Vector2i(-1, 1),
-	Vector2i(0, 1),
+    Vector2i(1, 0),
+    Vector2i(1, -1),
+    Vector2i(0, -1),
+    Vector2i(-1, 0),
+    Vector2i(-1, 1),
+    Vector2i(0, 1),
 ]
 
 static func seed_totems() -> void:
-	var cfg_variant: Variant = Config.decay().get("totems", {})
-	if typeof(cfg_variant) != TYPE_DICTIONARY:
-		RunState.decay_totems = []
-		RunState.decay_tiles = {}
-		RunState.decay_adjacent_age = {}
-		return
-	var cfg: Dictionary = cfg_variant
-	var count := int(cfg.get("count", 0))
-	RunState.decay_totems = []
-	RunState.decay_tiles = {}
-	RunState.decay_adjacent_age = {}
-	if count <= 0:
-		return
-	var spread_every := int(cfg.get("spread_every_turns", 3))
-	var min_radius := int(cfg.get("min_radius", 1))
-	var max_radius := int(cfg.get("max_radius", min_radius))
-	if max_radius < min_radius:
-		var tmp := min_radius
-		min_radius = max_radius
-		max_radius = tmp
-	var candidates: Array = []
-	for radius in range(max(min_radius, 1), max_radius + 1):
-		candidates.append_array(_ring_coords(radius))
-	var filtered: Array = []
-	for ax_variant in candidates:
-		if typeof(ax_variant) != TYPE_VECTOR2I:
-			continue
-		var ax: Vector2i = ax_variant
-		var key := Board.key(ax)
-		if RunState.connected_set.has(key):
-			continue
-		if filtered.has(ax):
-			continue
-		filtered.append(ax)
-	if filtered.is_empty():
-		return
-	var rng := RandomNumberGenerator.new()
-	rng.seed = int(RunState.seed)
-	while RunState.decay_totems.size() < count and filtered.size() > 0:
-		var index := rng.randi_range(0, filtered.size() - 1)
-		var chosen: Vector2i = filtered[index]
-		filtered.remove_at(index)
-		RunState.decay_totems.append({"ax": chosen, "timer": spread_every})
+    var cfg_variant: Variant = Config.decay().get("totems", {})
+    if typeof(cfg_variant) != TYPE_DICTIONARY:
+        RunState.decay_totems = []
+        RunState.decay_tiles = {}
+        RunState.decay_adjacent_age = {}
+        return
+    var cfg: Dictionary = cfg_variant
+    var count := int(cfg.get("count", 0))
+    RunState.decay_totems = []
+    RunState.decay_tiles = {}
+    RunState.decay_adjacent_age = {}
+    if count <= 0:
+        return
+    var spread_every := int(cfg.get("spread_every_turns", 3))
+    var min_radius := int(cfg.get("min_radius", 1))
+    var max_radius := int(cfg.get("max_radius", min_radius))
+    if max_radius < min_radius:
+        var tmp := min_radius
+        min_radius = max_radius
+        max_radius = tmp
+    var candidates: Array = []
+    for radius in range(max(min_radius, 1), max_radius + 1):
+        candidates.append_array(_ring_coords(radius))
+    var filtered: Array = []
+    for ax_variant in candidates:
+        if typeof(ax_variant) != TYPE_VECTOR2I:
+            continue
+        var ax: Vector2i = ax_variant
+        var key := Board.key(ax)
+        if RunState.connected_set.has(key):
+            continue
+        if filtered.has(ax):
+            continue
+        filtered.append(ax)
+    if filtered.is_empty():
+        return
+    var rng := RandomNumberGenerator.new()
+    rng.seed = int(RunState.seed)
+    while RunState.decay_totems.size() < count and filtered.size() > 0:
+        var index := rng.randi_range(0, filtered.size() - 1)
+        var chosen: Vector2i = filtered[index]
+        filtered.remove_at(index)
+        RunState.decay_totems.append({"ax": chosen, "timer": spread_every})
 
 static func do_spread(board: Node) -> void:
-	if board == null:
-		return
-	PathHex.set_board(board)
-	var cfg_variant: Variant = Config.decay().get("totems", {})
-	var cfg: Dictionary = {}
-	if typeof(cfg_variant) == TYPE_DICTIONARY:
-		cfg = cfg_variant
-	var spread_every := int(cfg.get("spread_every_turns", 3))
-	var global_cap := int(cfg.get("attacks_per_turn", 3))
-	var placed_this_turn := 0
-	for i in range(RunState.decay_totems.size()):
-		var totem_variant: Variant = RunState.decay_totems[i]
-		if typeof(totem_variant) != TYPE_DICTIONARY:
-			continue
-		var totem: Dictionary = totem_variant
-		var timer_value := int(totem.get("timer", spread_every)) - 1
-		totem["timer"] = timer_value
-		var should_attempt := timer_value <= 0
-		if should_attempt:
-			if placed_this_turn < global_cap:
-				var step_variant := _next_decay_step_from(totem.get("ax", Vector2i.ZERO))
-				if typeof(step_variant) == TYPE_VECTOR2I:
-					var step_ax: Vector2i = step_variant
-					if not board.is_decay(step_ax):
-						board.add_decay(step_ax)
-						var k := Board.key(step_ax)
-						RunState.decay_tiles[k] = {"age_adj_life": 0}
-						if RunState.overgrowth.has(k):
-							RunState.overgrowth.erase(k)
-						placed_this_turn += 1
-					else:
-						var existing_key := Board.key(step_ax)
-						if not RunState.decay_tiles.has(existing_key):
-							RunState.decay_tiles[existing_key] = {"age_adj_life": 0}
-		totem["timer"] = spread_every
-		RunState.decay_totems[i] = totem
+    if board == null:
+        return
+    PathHex.set_board(board)
+    var cfg_variant: Variant = Config.decay().get("totems", {})
+    var cfg: Dictionary = {}
+    if typeof(cfg_variant) == TYPE_DICTIONARY:
+        cfg = cfg_variant
+    var spread_every := int(cfg.get("spread_every_turns", 3))
+    var global_cap := int(cfg.get("attacks_per_turn", 3))
+    var placed_this_turn := 0
+    for i in range(RunState.decay_totems.size()):
+        var totem_variant: Variant = RunState.decay_totems[i]
+        if typeof(totem_variant) != TYPE_DICTIONARY:
+            continue
+        var totem: Dictionary = totem_variant
+        var timer_value := int(totem.get("timer", spread_every)) - 1
+        totem["timer"] = timer_value
+        var should_attempt := timer_value <= 0
+        if should_attempt:
+            if placed_this_turn < global_cap:
+                var step_variant := _next_decay_step_from(totem.get("ax", Vector2i.ZERO))
+                if typeof(step_variant) == TYPE_VECTOR2I:
+                    var step_ax: Vector2i = step_variant
+                    if not board.is_decay(step_ax):
+                        board.add_decay(step_ax)
+                        var k := Board.key(step_ax)
+                        RunState.decay_tiles[k] = {"age_adj_life": 0}
+                        if RunState.overgrowth.has(k):
+                            RunState.overgrowth.erase(k)
+                        placed_this_turn += 1
+                    else:
+                        var existing_key := Board.key(step_ax)
+                        if not RunState.decay_tiles.has(existing_key):
+                            RunState.decay_tiles[existing_key] = {"age_adj_life": 0}
+        totem["timer"] = spread_every
+        RunState.decay_totems[i] = totem
 
 static func apply_adjacency_corruption(board: Node) -> void:
-	if board == null:
-		return
-	var decay_axes := _gather_decay_axes(board)
-	var adjacent_life := {}
-	for ax in decay_axes:
-		for neighbor in neighbors(ax):
-			if not board.has_tile(neighbor):
-				continue
-			if board.is_decay(neighbor):
-				continue
-			adjacent_life[Board.key(neighbor)] = neighbor
-	var tracked_keys: Array = RunState.decay_adjacent_age.keys()
-	for key in tracked_keys:
-		if not adjacent_life.has(key):
-			RunState.decay_adjacent_age.erase(key)
-	for key in adjacent_life.keys():
-		var age := int(RunState.decay_adjacent_age.get(key, 0)) + 1
-		RunState.decay_adjacent_age[key] = age
-		if age >= 3:
-			var ax: Vector2i = adjacent_life[key]
-			board.replace_tile(ax, "Decay", "decay_base")
-			RunState.decay_tiles[key] = {"age_adj_life": 0}
-			RunState.decay_adjacent_age.erase(key)
-			if RunState.overgrowth.has(key):
-				RunState.overgrowth.erase(key)
-			if RunState.connected_set.has(key):
-				RunState.connected_set.erase(key)
+    if board == null:
+        return
+    var decay_axes := _gather_decay_axes(board)
+    var adjacent_life := {}
+    for ax in decay_axes:
+        for neighbor in neighbors(ax):
+            if not board.has_tile(neighbor):
+                continue
+            if board.is_decay(neighbor):
+                continue
+            adjacent_life[Board.key(neighbor)] = neighbor
+    var tracked_keys: Array = RunState.decay_adjacent_age.keys()
+    for key in tracked_keys:
+        if not adjacent_life.has(key):
+            RunState.decay_adjacent_age.erase(key)
+    for key in adjacent_life.keys():
+        var age := int(RunState.decay_adjacent_age.get(key, 0)) + 1
+        RunState.decay_adjacent_age[key] = age
+        if age >= 3:
+            var ax: Vector2i = adjacent_life[key]
+            board.replace_tile(ax, "Decay", "decay_base")
+            RunState.decay_tiles[key] = {"age_adj_life": 0}
+            RunState.decay_adjacent_age.erase(key)
+            if RunState.overgrowth.has(key):
+                RunState.overgrowth.erase(key)
+            if RunState.connected_set.has(key):
+                RunState.connected_set.erase(key)
 
 static func neighbors(ax: Vector2i) -> Array:
-	var out: Array = []
-	for dir in DIRECTIONS:
-		out.append(ax + dir)
-	return out
+    var out: Array = []
+    for dir in DIRECTIONS:
+        out.append(ax + dir)
+    return out
 
 static func _next_decay_step_from(ax_variant: Variant) -> Variant:
-	if typeof(ax_variant) != TYPE_VECTOR2I:
-		return null
-	return PathHex.nearest_connected_step(ax_variant)
+    if typeof(ax_variant) != TYPE_VECTOR2I:
+        return null
+    return PathHex.nearest_connected_step(ax_variant)
 
 static func _ring_coords(radius: int) -> Array:
-	var coords: Array = []
-	if radius <= 0:
-		return coords
-	var ax := Vector2i(-radius, radius)
-	for dir in DIRECTIONS:
-		for _i in range(radius):
-			coords.append(ax)
-			ax += dir
-	return coords
+    var coords: Array = []
+    if radius <= 0:
+        return coords
+    var ax := Vector2i(-radius, radius)
+    for dir in DIRECTIONS:
+        for _i in range(radius):
+            coords.append(ax)
+            ax += dir
+    return coords
 
 static func _gather_decay_axes(board: Node) -> Array:
-		var axes: Array = []
-		if board == null:
-				return axes
-		if board is Board:
-				var b: Board = board
-				for k in b.placed_tiles.keys():
-						var tile: Dictionary = b.placed_tiles[k]
-						if tile.get("category", "") == "Decay":
-								var ax := Board.unkey(k)
-								axes.append(ax)
-								if not RunState.decay_tiles.has(k):
-										RunState.decay_tiles[k] = {"age_adj_life": 0}
-		if axes.is_empty():
-				for key in RunState.decay_tiles.keys():
-						axes.append(Board.unkey(key))
-		return axes
+    var axes: Array = []
+    if board == null:
+        return axes
+    if board is Board:
+        var b: Board = board
+        for k in b.placed_tiles.keys():
+            var tile: Dictionary = b.placed_tiles[k]
+            if tile.get("category", "") == "Decay":
+                var ax := Board.unkey(k)
+                axes.append(ax)
+                if not RunState.decay_tiles.has(k):
+                    RunState.decay_tiles[k] = {"age_adj_life": 0}
+    if axes.is_empty():
+        for key in RunState.decay_tiles.keys():
+            axes.append(Board.unkey(key))
+    return axes

--- a/src/systems/ProducerRefine.gd
+++ b/src/systems/ProducerRefine.gd
@@ -11,7 +11,7 @@ static var last_water_gain: int = 0
 static func tick_and_convert(board: Node) -> void:
         last_water_gain = 0
         var cooldown_turns := _cooldown_turns()
-        var tiles := _placed_tiles(board)
+        var tiles: Dictionary = _placed_tiles(board)
         var active := {}
         for key in tiles.keys():
                 var tile: Dictionary = tiles[key]
@@ -60,7 +60,7 @@ static func _try_convert(_key: String) -> void:
         last_water_gain += gained
 
 static func _cooldown_turns() -> int:
-        var variant := Config.get_variant("Refine", "refine_default")
+        var variant: Dictionary = Config.get_variant("Refine", "refine_default")
         var effects: Dictionary = variant.get("effects", {})
         return int(effects.get("cooldown_turns", 2))
 

--- a/src/systems/Resources.gd
+++ b/src/systems/Resources.gd
@@ -11,18 +11,18 @@ const DEFAULT_LIFE_CAP := 999
 const Clusters := preload("res://src/systems/Clusters.gd")
 const ProducerRefine := preload("res://src/systems/ProducerRefine.gd")
 
-static var amount := {
-	"Nature": 0,
-	"Earth": 0,
-	"Water": 0,
-	"Life": 0,
+static var amount: Dictionary = {
+        "Nature": 0,
+        "Earth": 0,
+        "Water": 0,
+        "Life": 0,
 }
 
-static var cap := {
-	"Nature": 0,
-	"Earth": 0,
-	"Water": 0,
-	"Life": 0,
+static var cap: Dictionary = {
+        "Nature": 0,
+        "Earth": 0,
+        "Water": 0,
+        "Life": 0,
 }
 
 static func reset() -> void:
@@ -40,15 +40,15 @@ static func set_cap(type: String, value: int) -> void:
 		amount[key] = clamp(amount[key], 0, clamped)
 
 static func add(type: String, delta: int) -> int:
-	var key := _ensure_type(type)
-	var before := amount[key]
-	var limit := cap[key]
-	if limit <= 0 and key != "Life":
-		amount[key] = max(0, min(before + delta, 0))
-	else:
-		var max_value := limit if limit > 0 else before + delta
-		amount[key] = clamp(before + delta, 0, max_value)
-	return amount[key] - before
+        var key := _ensure_type(type)
+        var before: int = int(amount.get(key, 0))
+        var limit: int = int(cap.get(key, 0))
+        if limit <= 0 and key != "Life":
+                amount[key] = max(0, min(before + delta, 0))
+        else:
+                var max_value: int = limit if limit > 0 else before + delta
+                amount[key] = clamp(before + delta, 0, max_value)
+        return int(amount[key]) - before
 
 static func get_amount(type: String) -> int:
 	var key := _ensure_type(type)

--- a/src/ui/Draft.gd
+++ b/src/ui/Draft.gd
@@ -68,7 +68,7 @@ func _sample_three(cat:String) -> Array[Dictionary]:
     var available := variants.size()
     if available <= 0:
         return []
-    var count := min(3, available)
+    var count: int = min(3, available)
     var results : Array[Dictionary] = []
     for i in range(count):
         var idx := _rng.randi_range(0, variants.size() - 1)
@@ -170,7 +170,7 @@ func _confirm_pick():
     if _choices.is_empty():
         return
     var cat: String = _categories[_index]
-    var sel := clamp(_current_sel(), 0, _choices.size() - 1)
+    var sel: int = clamp(_current_sel(), 0, _choices.size() - 1)
     var picked_id := str(_choices[sel].get("id", ""))
     if picked_id != "":
         _picked[cat] = picked_id

--- a/src/ui/PanelSwitcher.gd
+++ b/src/ui/PanelSwitcher.gd
@@ -1,9 +1,9 @@
 extends Node
 class_name PanelSwitcher
 
-var _panels : Dictionary = {}
-var _order : Array = []
-var _current := ""
+var _panels: Dictionary = {}
+var _order: Array[String] = []
+var _current: String = ""
 
 func _ready() -> void:
     ensure_draft_panel()
@@ -26,9 +26,11 @@ func ensure_draft_panel() -> void:
 func show(name:String) -> void:
     if not _panels.has(name):
         return
-    for key in _panels.keys():
-        var panel = _panels[key]
-        if panel is CanvasItem:
+    for raw_key in _panels.keys():
+        var key: String = str(raw_key)
+        var panel_value: Variant = _panels[key]
+        if panel_value is CanvasItem:
+            var panel: CanvasItem = panel_value
             panel.visible = key == name
     _current = name
 


### PR DESCRIPTION
## Summary
- normalize indentation in PathHex and Decay scripts to resolve parsing errors
- convert the Config singleton to use static accessors and tighten typing across dependent systems
- add explicit type annotations in resource and UI scripts to eliminate Variant inference warnings

## Testing
- not run (godot executable unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5d47736e48322a58551c1c15ae897